### PR TITLE
Porting scripts from cloudstackOps

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,11 @@
+[report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    def __getitem__
+    def __iter__
+    def __len__
+    raise AssertionError
+    raise NotImplementedError
+    if 0:
+    if __name__ == .__main__.:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,39 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python package
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        sudo apt-get install -y libmariadb3 libmariadb-dev
+        python -m pip install --upgrade pip
+        pip install flake8 pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+    - name: Test with pytest
+      run: |
+        pytest
+

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# PyCharm
+.idea/

--- a/config.example
+++ b/config.example
@@ -1,0 +1,5 @@
+[mariadb-alias]
+host = localhost
+port = 3306
+user = cloud
+password = secret

--- a/cosmicops/__init__.py
+++ b/cosmicops/__init__.py
@@ -1,0 +1,21 @@
+# Copyright 2020, Schuberg Philis B.V
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .cluster import CosmicCluster
+from .host import CosmicHost
+from .ops import CosmicOps
+from .sql import CosmicSQL
+from .vm import CosmicVM
+
+__all__ = [CosmicOps, CosmicSQL, CosmicHost, CosmicCluster, CosmicVM]

--- a/cosmicops/cluster.py
+++ b/cosmicops/cluster.py
@@ -1,0 +1,36 @@
+# Copyright 2020, Schuberg Philis B.V
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Mapping
+
+from .host import CosmicHost
+
+
+class CosmicCluster(Mapping):
+    def __init__(self, ops, cluster):
+        self._ops = ops
+        self._cluster = cluster
+
+    def __getitem__(self, item):
+        return self._cluster[item]
+
+    def __iter__(self):
+        return iter(self._cluster)
+
+    def __len__(self):
+        return len(self._cluster)
+
+    def get_all_hosts(self):
+        return [CosmicHost(self._ops, host) for host in
+                self._ops.cs.listHosts(clusterid=self['id'], listall='true').get('host', [])]

--- a/cosmicops/host.py
+++ b/cosmicops/host.py
@@ -1,0 +1,303 @@
+# Copyright 2020, Schuberg Philis B.V
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import socket
+import time
+from collections.abc import Mapping
+from enum import Enum, auto
+from operator import itemgetter
+
+import click_spinner
+from fabric import Connection
+
+from .vm import CosmicVM
+
+
+class RebootAction(Enum):
+    REBOOT = auto()
+    HALT = auto()
+    FORCE_RESET = auto()
+    UPGRADE_FIRMWARE = auto()
+    SKIP = auto()
+
+
+class CosmicHost(Mapping):
+    def __init__(self, ops, host):
+        self._ops = ops
+        self._host = host
+        self.dry_run = ops.dry_run
+        self._connection = Connection(self._host['name'])
+        self.vms_with_shutdown_policy = []
+
+    def __getitem__(self, item):
+        return self._host[item]
+
+    def __iter__(self):
+        return iter(self._host)
+
+    def __len__(self):
+        return len(self._host)
+
+    def refresh(self):
+        self._host = self._ops.get_host_json_by_id(self['id'])[0]
+
+    def disable(self):
+        if self.dry_run:
+            logging.info(f"Would disable host '{self['name']}'")
+            return True
+        else:
+            logging.info(f"Disabling host '{self['name']}'")
+
+        if not self._ops.cs.updateHost(id=self['id'], allocationstate='Disable').get('host'):
+            logging.error(f"Failed to disable host '{self['name']}'")
+            return False
+
+        with click_spinner.spinner():
+            while True:
+                self.refresh()
+                if self['resourcestate'] == 'Disabled':
+                    break
+                time.sleep(5)
+
+        return True
+
+    def enable(self):
+        if self.dry_run:
+            logging.info(f"Would enable host '{self['name']}'")
+            return True
+        else:
+            logging.info(f"Enabling host '{self['name']}'")
+
+        if not self._ops.cs.updateHost(id=self['id'], allocationstate='Enable').get('host'):
+            logging.error(f"Failed to enable host '{self['name']}'")
+            return False
+
+        with click_spinner.spinner():
+            while True:
+                self.refresh()
+                if self['resourcestate'] == 'Enabled':
+                    break
+                time.sleep(5)
+
+        return True
+
+    def empty(self):
+        total = success = failed = 0
+
+        all_vms = self.get_all_vms()
+        if not all_vms:
+            logging.warning(f"No VMs found on host '{self['name']}'")
+            return total, success, failed
+
+        total = len(all_vms)
+
+        if self.dry_run:
+            logging.info(f"Dry run of VM migration away from host '{self['name']}'")
+        else:
+            logging.info(f"Migrating VMs away from host '{self['name']}'")
+
+        for vm in all_vms:
+            if vm.get('maintenancepolicy') == 'ShutdownAndStart':
+                # TODO: currently the VM remains stopped, would be nice to have it start again if possible.
+                # * Do not try to start if the host is on NVMe
+                # * If it's on shared storage it can be started on another host after this one has been disabled
+                self.vms_with_shutdown_policy.append(vm)
+
+                if not vm.stop():
+                    failed += 1
+                else:
+                    success += 1
+
+                continue
+
+            vm_on_dedicated_hv = False
+            dedicated_affinity_id = None
+            for affinity_group in vm.get_affinity_groups():
+                if affinity_group['type'] == 'ExplicitDedication':
+                    vm_on_dedicated_hv = True
+                    dedicated_affinity_id = affinity_group['id']
+
+            available_hosts = self._ops.cs.findHostsForMigration(virtualmachineid=vm['id']).get('host', [])
+            available_hosts.sort(key=itemgetter('memoryallocated'))
+            migration_host = None
+
+            for available_host in available_hosts:
+                # Skip hosts that require storage migration
+                if available_host['requiresStorageMotion']:
+                    logging.debug(
+                        f"Skipping '{available_host['name']}' because migrating VM '{vm['name']}' requires a storage migration")
+                    continue
+
+                # Only hosts in the same cluster
+                if available_host['clusterid'] != self['clusterid']:
+                    logging.debug(f"Skipping '{available_host['name']}' because it's part of a different cluster")
+                    continue
+
+                # Ensure host is suitable for migration
+                if not available_host['suitableformigration']:
+                    logging.debug(f"Skipping '{available_host['name']}' because it's not suitable for migration")
+                    continue
+
+                if vm_on_dedicated_hv:
+                    # Ensure the dedication group matches
+                    if available_host.get('affinitygroupid') != dedicated_affinity_id:
+                        logging.info(
+                            f"Skipping '{available_host['name']}' because host does not match the dedication group of VM '{vm['name']}'")
+                        continue
+                else:
+                    # VM isn't dedicated, so skip dedicated hosts
+                    if 'affinitygroupid' in available_host:
+                        logging.info(
+                            f"Skipping '{available_host['name']}' because host is dedicated and VM '{vm['name']}' is not")
+                        continue
+
+                logging.debug(f"Selected '{available_host['name']}' for VM '{vm['name']}'")
+                migration_host = available_host
+                break
+
+            if not migration_host:
+                logging.error(
+                    f"Failed to find host with capacity to migrate VM '{vm['name']}'. Please migrate manually to another cluster.")
+                failed += 1
+                continue
+
+            if not vm.migrate(migration_host):
+                failed += 1
+            else:
+                success += 1
+
+        return total, success, failed
+
+    def get_all_vms(self):
+        vms = self._ops.cs.listVirtualMachines(hostid=self['id'], listall='true').get('virtualmachine', [])
+        project_vms = self._ops.cs.listVirtualMachines(hostid=self['id'], listall='true', projectid='-1').get(
+            'virtualmachine', [])
+        routers = self._ops.cs.listRouters(hostid=self['id'], listall='true').get('router', [])
+        project_routers = self._ops.cs.listRouters(hostid=self['id'], listall='true', projectid='-1').get('router', [])
+        system_vms = self._ops.cs.listSystemVms(hostid=self['id']).get('systemvm', [])
+
+        all_vms = vms + project_vms + routers + project_routers + system_vms
+        return [CosmicVM(self._ops, vm) for vm in all_vms]
+
+    def copy_file(self, source, destination, mode=None):
+        if self.dry_run:
+            logging.info(f"Would copy '{source}' to '{destination}' on '{self['name']}")
+            return
+
+        self._connection.put(source, destination)
+        if mode:
+            self._connection.sudo(f'chmod {mode:o} {destination}')
+
+    def execute(self, command, sudo=False):
+        if self.dry_run:
+            logging.info(f"Would execute '{command}' on '{self['name']}")
+            return
+
+        if sudo:
+            runner = self._connection.sudo
+        else:
+            runner = self._connection.run
+
+        return runner(command)
+
+    def reboot(self, action=RebootAction.REBOOT):
+        if self.dry_run:
+            logging.info(f"Would reboot host '{self['name']}' with action '{action}'")
+            return True
+
+        if self.execute('virsh list | grep running | wc -l').stdout.strip() != '0':
+            logging.error(f"Host '{self['name']}' has running VMs, will not reboot")
+            return False
+
+        try:
+            if action == RebootAction.REBOOT:
+                logging.info(f"Rebooting '{self['name']}' in 60s")
+                self.execute('shutdown -r 1', sudo=True)
+            elif action == RebootAction.HALT:
+                logging.info(f"Halting '{self['name']}' in 60s")
+                self.execute('shutdown -h 1', sudo=True)
+            elif action == RebootAction.FORCE_RESET:
+                logging.info(f"Force resetting '{self['name']}'")
+                self.execute('sync', sudo=True)
+                self.execute('echo b > /proc/sysrq-trigger', sudo=True)
+            elif action == RebootAction.UPGRADE_FIRMWARE:
+                logging.info(f"Rebooting '{self['name']}' after firmware upgrade")
+                self.execute("tmux new -d 'yes | sudo /usr/sbin/smartupdate upgrade && sudo reboot'")
+            elif action == RebootAction.SKIP:
+                logging.info(f"Skipping reboot for '{self['name']}'")
+        except Exception as e:
+            logging.warning(f"Ignoring exception as it's likely related to the reboot: {e}")
+
+        return True
+
+    def wait_until_offline(self):
+        if self.dry_run:
+            logging.info(f"Would wait for '{self['name']}' to complete it's reboot")
+        else:
+            logging.info(f"Waiting for '{self['name']}' to complete it's reboot")
+            with click_spinner.spinner():
+                while True:
+                    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                        s.settimeout(5)
+                        result = s.connect_ex((self['name'], 22))
+
+                    if result != 0:
+                        break
+                    time.sleep(5)
+
+    def wait_until_online(self):
+        if self.dry_run:
+            logging.info(f"Would wait for '{self['name']}' to come back online")
+        else:
+            logging.info(f"Waiting for '{self['name']}' to come back online")
+            with click_spinner.spinner():
+                while True:
+                    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                        s.settimeout(5)
+                        result = s.connect_ex((self['name'], 22))
+
+                    if result == 0:
+                        break
+
+        if self.dry_run:
+            logging.info(f"Would wait for libvirt on '{self['name']}'")
+        else:
+            logging.info(f"Waiting for libvirt on '{self['name']}'")
+            with click_spinner.spinner():
+                while self.execute('virsh list').return_code != 0:
+                    time.sleep(5)
+
+    def restart_vms_with_shutdown_policy(self):
+        for vm in self.vms_with_shutdown_policy:
+            vm.start()
+
+    def wait_for_agent(self):
+        if self.dry_run:
+            logging.info(f"Would wait for agent to became up on host '{self['name']}'")
+            return
+        else:
+            logging.info(f"Waiting for agent on host '{self['name']}'")
+
+        with click_spinner.spinner():
+            while True:
+                self.refresh()
+                if self['state'] == 'Up':
+                    break
+
+                time.sleep(5)
+
+    def __del__(self):
+        if self._connection:
+            self._connection.close()

--- a/cosmicops/ops.py
+++ b/cosmicops/ops.py
@@ -1,0 +1,108 @@
+# Copyright 2020, Schuberg Philis B.V
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import time
+from configparser import ConfigParser
+from pathlib import Path
+
+import click_spinner
+from cs import CloudStack, CloudStackException
+from requests.exceptions import ConnectionError
+
+from .cluster import CosmicCluster
+from .host import CosmicHost
+
+
+def load_cloud_monkey_profile(profile):
+    config_file = Path.home() / '.cloudmonkey' / 'config'
+    config = ConfigParser()
+    config.read(str(config_file))
+    logging.debug(f"Loading profile '{profile}' from config '{config_file}'")
+
+    if profile == 'config':
+        profile = config['core']['profile']
+
+    return config[profile]['url'], config[profile]['apikey'], config[profile]['secretkey']
+
+
+class CosmicOps(object):
+    def __init__(self, endpoint=None, key=None, secret=None, profile=None, timeout=60, dry_run=False):
+        if profile:
+            (endpoint, key, secret) = load_cloud_monkey_profile(profile)
+
+        self.endpoint = endpoint
+        self.key = key
+        self.secret = secret
+
+        self.timeout = timeout
+        self.dry_run = dry_run
+        self.cs = CloudStack(self.endpoint, self.key, self.secret, self.timeout)
+
+    def get_host_by_name(self, host_name):
+        response = self.cs.listHosts(name=host_name).get('host')
+
+        if not response:
+            logging.error(f"Host '{host_name}' not found")
+            return None
+        elif len(response) != 1:
+            logging.error(f"Lookup for host '{host_name}' returned multiple results")
+            return None
+
+        return CosmicHost(self, response[0])
+
+    def get_host_json_by_id(self, host_id):
+        return self.cs.listHosts(id=host_id).get('host')
+
+    def get_cluster_by_name(self, cluster_name):
+        response = self.cs.listClusters(name=cluster_name).get('cluster')
+
+        if not response:
+            logging.error(f"Cluster '{cluster_name}' not found")
+            return None
+        elif len(response) != 1:
+            logging.error(f"Lookup for cluster '{cluster_name}' returned multiple results")
+            return None
+
+        return CosmicCluster(self, response[0])
+
+    def wait_for_job(self, job_id, retries=10):
+        job_status = 0
+
+        with click_spinner.spinner():
+            while True:
+                if retries <= 0:
+                    break
+
+                try:
+                    job_status = self.cs.queryAsyncJobResult(jobid=job_id).get('jobstatus', 0)
+                except CloudStackException as e:
+                    if 'multiple JSON fields named jobstatus' not in str(e):
+                        raise e
+                    logging.debug(e)
+                    retries -= 1
+                except ConnectionError as e:
+                    if 'Connection aborted' not in str(e):
+                        raise e
+                    logging.debug(e)
+                    retries -= 1
+
+                if int(job_status) == 1:
+                    return True
+                elif int(job_status) == 2:
+                    break
+
+                time.sleep(1)
+
+        return False

--- a/cosmicops/sql.py
+++ b/cosmicops/sql.py
@@ -1,0 +1,83 @@
+# Copyright 2020, Schuberg Philis B.V
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from configparser import ConfigParser, NoOptionError
+from pathlib import Path
+
+import mariadb
+
+
+class CosmicSQL(object):
+    def __init__(self, server, port=3306, password=None, user='cloud', dry_run=False):
+        self.server = server
+        self.port = port
+        self.user = user
+        self.password = password
+        self.dry_run = dry_run
+        self.conn = None
+
+        self._connect()
+
+    def _connect(self):
+        if not self.password:
+            config_file = Path.cwd() / 'config'
+            config = ConfigParser()
+            config.read(str(config_file))
+            logging.debug(f"Loading SQL server details for '{self.server}' from '{config_file}'")
+
+            if self.server not in config:
+                logging.error(f"Could not find configuration section for '{self.server}' in '{config_file}'")
+                raise RuntimeError
+
+            try:
+                self.password = config.get(self.server, 'password')
+                self.user = config.get(self.server, 'user', fallback=self.user)
+                self.port = config.getint(self.server, 'port', fallback=self.port)
+                self.server = config.get(self.server, 'host', fallback=self.server)
+            except NoOptionError as e:
+                logging.error(f"Unable to read details from '{config_file}' for '{self.server}': {e}")
+                raise
+
+        try:
+            self.conn = mariadb.connect(host=self.server, port=self.port, user=self.user, password=self.password)
+        except mariadb.Error as e:
+            logging.error(f"Error connecting to server '{self.server}': {e}")
+            raise
+
+        self.conn.autocommit = False
+
+    def kill_jobs_of_instance(self, instance_id):
+        cursor = self.conn.cursor()
+
+        try:
+            queries = [
+                'DELETE FROM `async_job` WHERE `instance_id` = ?',
+                'DELETE FROM `vm_work_job` WHERE `vm_instance_id` = ?',
+                'DELETE FROM `sync_queue` WHERE `sync_objid` = ?'
+            ]
+
+            for query in queries:
+                cursor.execute(query, (instance_id,))
+                if self.dry_run:
+                    logging.info(f'Would have executed: {cursor.statement}')
+                else:
+                    cursor.commit()
+        except mariadb.Error as e:
+            logging.error(f'Error while executing query "{cursor.statement}": {e}')
+            return False
+        finally:
+            cursor.close()
+
+        return True

--- a/cosmicops/vm.py
+++ b/cosmicops/vm.py
@@ -1,0 +1,104 @@
+# Copyright 2020, Schuberg Philis B.V
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from collections.abc import Mapping
+
+from cs import CloudStackException
+
+
+class CosmicVM(Mapping):
+    def __init__(self, ops, vm):
+        self._ops = ops
+        self._vm = vm
+        self.dry_run = ops.dry_run
+
+    def __getitem__(self, item):
+        return self._vm[item]
+
+    def __iter__(self):
+        return iter(self._vm)
+
+    def __len__(self):
+        return len(self._vm)
+
+    def stop(self):
+        if self.dry_run:
+            logging.info(
+                f"Would shut down VM '{self['name']}' on host '{self['hostname']}' as it has a ShutdownAndStart policy")
+            return True
+
+        logging.info(f"Stopping VM '{self['name']}'")
+        stop_response = self._ops.cs.stopVirtualMachine(id=self['id'])
+        if not self._ops.wait_for_job(stop_response['jobid']):
+            logging.error(f"Failed to shutdown VM '{self['name']}' on host '{self['hostname']}'")
+            return False
+
+        return True
+
+    def start(self):
+        if self.dry_run:
+            logging.info(f"Would start VM '{self['name']}")
+            return True
+
+        logging.info(f"Starting VM '{self['name']}'")
+        start_response = self._ops.cs.startVirtualMachine(id=self['id'])
+        if not self._ops.wait_for_job(start_response['jobid']):
+            logging.error(f"Failed to start VM '{self['name']}'")
+            return False
+
+        return True
+
+    def get_affinity_groups(self):
+        affinity_groups = []
+        try:
+            affinity_groups = self._ops.cs.listAffinityGroups(virtualmachineid=self['id']).get('affinitygroup', [])
+        except CloudStackException:
+            pass
+
+        return affinity_groups
+
+    def migrate(self, target_host):
+        if self.dry_run:
+            logging.info(f"Would live migrate VM '{self['name']}' to '{target_host['name']}'")
+            return True
+
+        try:
+            logging.info(f"Live migrating VM '{self['name']}' to '{target_host['name']}'")
+
+            if 'instancename' in self:
+                if 'isoid' in self:
+                    self._ops.cs.detachIso(virtualmachineid=self['id'])
+
+                vm_result = self._ops.cs.migrateVirtualMachine(virtualmachineid=self['id'],
+                                                               hostid=target_host['id'])
+                if not vm_result:
+                    raise RuntimeError
+            else:
+                vm_result = self._ops.cs.migrateSystemVm(virtualmachineid=self['id'], hostid=target_host['id'])
+                if not vm_result:
+                    raise RuntimeError
+        except (CloudStackException, RuntimeError):
+            logging.error(f"Failed to migrate VM '{self['name']}'")
+            return False
+
+        job_id = vm_result['jobid']
+        if not self._ops.wait_for_job(job_id):
+            logging.error(f"Migration job '{vm_result['jobid']}' failed")
+            return False
+
+        logging.debug(f"Migration job '{vm_result['jobid']}' completed")
+
+        logging.debug(f"Successfully migrated VM '{self['name']}' to '{target_host['name']}'")
+        return True

--- a/empty_host.py
+++ b/empty_host.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# Copyright 2020, Schuberg Philis B.V
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import sys
+
+import click
+import click_log
+
+from cosmicops import CosmicOps
+
+
+@click.command()
+@click.option('--profile', '-p', metavar='<name>', default='config',
+              help='Name of the CloudMonkey profile containing the credentials')
+@click.option('--dry-run', '-n', is_flag=True, help='Enable dry-run')
+@click_log.simple_verbosity_option(logging.getLogger(), default="INFO")
+@click.argument('host')
+def main(profile, dry_run, host):
+    """Empty HOST by migrating VMs to another host in the same cluster."""
+
+    click_log.basic_config()
+
+    if dry_run:
+        logging.info('Running in dry-run mode, will only show changes')
+
+    co = CosmicOps(profile=profile, dry_run=dry_run)
+
+    host = co.get_host_by_name(host)
+    if not host:
+        sys.exit(1)
+
+    (total, success, failed) = host.empty()
+    logging.info(f"Result: {success} successful, {failed} failed out of {total} total VMs")
+
+
+if __name__ == '__main__':
+    main()

--- a/kill_jobs.py
+++ b/kill_jobs.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# Copyright 2020, Schuberg Philis B.V
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import click
+import click_log
+
+from cosmicops import CosmicSQL
+
+
+@click.command()
+@click.option('--database-server', '-s', metavar='<address>', required=True,
+              help='Address or alias of Cosmic database server')
+@click.option('--database-port', metavar='<port>', default=3306, show_default=True,
+              help='Port number of the database server')
+@click.option('--database-user', '-u', metavar='<user>', default='cloud', show_default=True,
+              help='Username of database account')
+@click.option('--database-password', '-p', metavar='<password>', required=True, help='Password of the database user')
+@click.option('--dry-run', '-n', is_flag=True, help='Enable dry-run')
+@click_log.simple_verbosity_option(logging.getLogger(), default="INFO")
+@click.argument('instance_id')
+def main(database_server, database_port, database_user, database_password, dry_run, instance_id):
+    """Kills all jobs related to INSTANCE_ID"""
+
+    click_log.basic_config()
+
+    if dry_run:
+        logging.warning('Running in dry-run mode, will only show changes')
+
+    cs = CosmicSQL(server=database_server, port=database_port, user=database_user, password=database_password,
+                   dry_run=dry_run)
+
+    cs.kill_jobs_of_instance(instance_id)
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+click~=7.1.2
+click-log~=0.3.2
+click-spinner~=0.1.10
+cs~=3.0.0
+fabric~=2.5.0
+mariadb~=1.0.0
+requests~=2.24.0
+testfixtures~=6.14.1

--- a/rolling_reboot.py
+++ b/rolling_reboot.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# Copyright 2020, Schuberg Philis B.V
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import sys
+import time
+from operator import itemgetter
+from pathlib import Path
+
+import click
+import click_log
+
+from cosmicops import CosmicOps
+from cosmicops.host import RebootAction
+
+
+@click.command()
+@click.option('--profile', '-p', default='config', help='Name of the CloudMonkey profile containing the credentials')
+@click.option('--ignore-hosts', metavar='<list>',
+              help='Comma separated list of hosts to skip (--ignore-host="host1, host2")')
+@click.option('--only-hosts', metavar='<list>',
+              help='Comma separated list of hosts to work on (--only-host="host1, host2")')
+@click.option('--skip-os-version', metavar='<version>', help='Skips hosts matching the specified OS version')
+@click.option('--reboot', 'reboot_action', flag_value=RebootAction.REBOOT, default=True,
+              help='Reboot the host [default]')
+@click.option('--halt', 'reboot_action', flag_value=RebootAction.HALT, help='Instead of rebooting, halt the host')
+@click.option('--force-reset', 'reboot_action', flag_value=RebootAction.FORCE_RESET,
+              help='Instead of reboot, force-reset the host')
+@click.option('--skip-reboot', 'reboot_action', flag_value=RebootAction.SKIP, help='Skip rebooting the host')
+@click.option('--upgrade-firmware', 'reboot_action', flag_value=RebootAction.UPGRADE_FIRMWARE,
+              help='Update the HP firmware and reboot')
+@click.option('--pre-empty-script', metavar='<script>', help='Script to run on host before starting live migrations')
+@click.option('--post-empty-script', metavar='<script>',
+              help='Script to run on host after live migrations have completed')
+@click.option('--post-reboot-script', metavar='<script>', help='Script to run after host has rebooted')
+@click.option('--dry-run', '-n', is_flag=True, help='Enable dry-run')
+@click_log.simple_verbosity_option(logging.getLogger(), default="INFO")
+@click.argument('cluster')
+def main(profile, ignore_hosts, only_hosts, skip_os_version, reboot_action, pre_empty_script, post_empty_script,
+         post_reboot_script, dry_run, cluster):
+    """Perform rolling reboot of hosts in CLUSTER"""
+
+    click_log.basic_config()
+
+    if dry_run:
+        logging.warning('Running in dry-run mode, will only show changes')
+
+    co = CosmicOps(profile=profile, dry_run=dry_run)
+
+    cluster = co.get_cluster_by_name(cluster)
+    if not cluster:
+        sys.exit(1)
+
+    hosts = cluster.get_all_hosts()
+    logging.debug(f"Found hosts: {hosts}")
+
+    if ignore_hosts:
+        ignore_hosts = ignore_hosts.replace(' ', '').split(',')
+        logging.info(f"Ignoring hosts: {str(ignore_hosts)}")
+
+        hosts = [h for h in hosts if h['name'] not in ignore_hosts]
+    elif only_hosts:
+        only_hosts = only_hosts.replace(' ', '').split(',')
+        logging.info(f"Only processing hosts: {str(only_hosts)}")
+        hosts = [h for h in hosts if h['name'] in only_hosts]
+
+    if skip_os_version:
+        logging.info(f"Skipping hosts with OS: {skip_os_version}")
+        hosts = [h for h in hosts if skip_os_version not in h['hypervisorversion']]
+
+    hosts.sort(key=itemgetter('name'))
+
+    for host in hosts:
+        for script in filter(None, (pre_empty_script, post_empty_script, post_reboot_script)):
+            path = Path(script)
+            host.copy_file(str(path), f'/tmp/{path.name}', mode=0o755)
+
+        if pre_empty_script:
+            host.execute(f'/tmp/{Path(pre_empty_script).name}', sudo=True)
+
+        if host['resourcestate'] != 'Disabled':
+            if not host.disable():
+                sys.exit(1)
+
+        if host['state'] != 'Up' and not dry_run:
+            logging.error(f"Host '{host['name']} is not up (state: '{host['state']}'), aborting")
+            sys.exit(1)
+
+        while True:
+            (_, _, failed) = host.empty()
+            if failed == 0 or dry_run:
+                break
+
+            logging.warning(f"Failed to empty host {host['name']}, retrying...")
+            time.sleep(5)
+
+        if post_empty_script:
+            host.execute(f'/tmp/{Path(post_empty_script).name}', sudo=True)
+
+        if not host.reboot(reboot_action):
+            sys.exit(1)
+
+        if reboot_action != RebootAction.SKIP:
+            host.wait_until_offline()
+            host.wait_until_online()
+
+        if post_reboot_script:
+            host.execute(f'/tmp/{Path(post_reboot_script).name}', sudo=True)
+
+        if not host.enable():
+            sys.exit(1)
+
+        host.wait_for_agent()
+
+        host.restart_vms_with_shutdown_policy()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2020, Schuberg Philis B.V
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/test_cosmiccluster.py
+++ b/tests/test_cosmiccluster.py
@@ -1,0 +1,48 @@
+# Copyright 2020, Schuberg Philis B.V
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import TestCase
+from unittest.mock import patch
+
+from cosmicops import CosmicOps, CosmicCluster
+
+
+class TestCosmicCluster(TestCase):
+    def setUp(self):
+        cs_patcher = patch('cosmicops.ops.CloudStack')
+        self.mock_cs = cs_patcher.start()
+        self.addCleanup(cs_patcher.stop)
+        self.cs_instance = self.mock_cs.return_value
+
+        self.ops = CosmicOps(endpoint='https://localhost', key='key', secret='secret')
+        self.cluster = CosmicCluster(self.ops, {
+            'id': 'c1',
+            'name': 'cluster1'
+        })
+
+    def test_get_all_hosts(self):
+        self.cs_instance.listHosts.return_value = {
+            'host': [{
+                'id': 'h1',
+                'name': 'host1'
+            }, {
+                'id': 'h2',
+                'name': 'host2'
+            }]
+        }
+
+        hosts = self.cluster.get_all_hosts()
+        self.assertEqual(2, len(hosts))
+        self.assertEqual({'id': 'h1', 'name': 'host1'}, hosts[0]._host)
+        self.assertEqual({'id': 'h2', 'name': 'host2'}, hosts[1]._host)

--- a/tests/test_cosmichost.py
+++ b/tests/test_cosmichost.py
@@ -1,0 +1,481 @@
+# Copyright 2020, Schuberg Philis B.V
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import TestCase
+from unittest.mock import Mock, patch, call
+
+from cosmicops import CosmicOps, CosmicHost, CosmicVM
+from cosmicops.host import RebootAction
+
+
+class TestCosmicHost(TestCase):
+    def setUp(self):
+        cs_patcher = patch('cosmicops.ops.CloudStack')
+        self.mock_cs = cs_patcher.start()
+        self.addCleanup(cs_patcher.stop)
+        self.cs_instance = self.mock_cs.return_value
+
+        connection_patcher = patch('cosmicops.host.Connection')
+        self.mock_connection = connection_patcher.start()
+        self.addCleanup(connection_patcher.stop)
+        self.connection_instance = self.mock_connection.return_value
+
+        socket_patcher = patch('socket.socket')
+        self.mock_socket = socket_patcher.start()
+        self.addCleanup(socket_patcher.stop)
+        self.socket_context = self.mock_socket.return_value.__enter__.return_value
+
+        sleep_patcher = patch('time.sleep', return_value=None)
+        self.mock_sleep = sleep_patcher.start()
+        self.addCleanup(sleep_patcher.stop)
+
+        self.ops = CosmicOps(endpoint='https://localhost', key='key', secret='secret')
+
+        self.user_vm = CosmicVM(self.ops, {
+            'id': 'v1',
+            'name': 'vm1',
+            'instancename': 'i-1-VM',
+            'hostname': 'host1',
+            'maintenancepolicy': 'LiveMigrate',
+            'isoid': 'iso1'
+        })
+        self.router_vm = CosmicVM(self.ops, {
+            'id': 'r1',
+            'name': 'r-1-VM',
+            'hostname': 'host1'
+        })
+        self.secondary_storage_vm = CosmicVM(self.ops, {
+            'id': 's1',
+            'name': 's-1-VM',
+            'hostname': 'host1',
+            'systemvmtype': 'secondarystoragevm'
+        })
+
+        self.console_proxy = CosmicVM(self.ops, {
+            'id': 's2',
+            'name': 'v-2-VM',
+            'hostname': 'host1',
+            'systemvmtype': 'consoleproxy'
+        })
+
+        self.all_vms = [self.user_vm, self.router_vm, self.secondary_storage_vm, self.console_proxy]
+
+        self.host = CosmicHost(self.ops, {
+            'id': 'h1',
+            'name': 'host1',
+            'clusterid': '1'
+        })
+
+    def _mock_cosmic_vm_calls(self):
+        self.cs_instance.listVirtualMachines.side_effect = [
+            {
+                'virtualmachine': [{
+                    'id': 'v1',
+                    'name': 'vm1',
+                    'instancename': 'i-1-VM',
+                    'hostname': 'host1',
+                    'maintenancepolicy': 'LiveMigrate',
+                    'isoid': 'iso1'
+                }]
+            },
+            {}
+        ]
+        self.cs_instance.listRouters.side_effect = [
+            {
+                'router': [{
+                    'id': 'r1',
+                    'name': 'r-1-VM',
+                    'hostname': 'host1'
+                }]
+            },
+            {}
+        ]
+        self.cs_instance.listSystemVms.side_effect = [
+            {
+                'systemvm': [{
+                    'id': 's1',
+                    'name': 's-1-VM',
+                    'hostname': 'host1',
+                    'systemvmtype': 'secondarystoragevm'
+                }, {
+                    'id': 's2',
+                    'name': 'v-2-VM',
+                    'hostname': 'host1',
+                    'systemvmtype': 'consoleproxy'
+                }]
+            },
+            {}
+        ]
+
+    def _mock_hosts_and_vms(self):
+        for vm in self.all_vms:
+            vm.stop = Mock(return_value=True)
+            vm.start = Mock(return_value=True)
+            vm.get_affinity_groups = Mock(return_value=[])
+            vm.migrate = Mock(return_value=True)
+
+        self.host.get_all_vms = Mock(return_value=self.all_vms)
+
+        self.cs_instance.findHostsForMigration.return_value = {
+            'host': [{
+                'id': 'host_high_mem',
+                'name': 'host2',
+                'memoryallocated': 1000,
+                'clusterid': '1',
+                'requiresStorageMotion': False,
+                'suitableformigration': True
+            }, {
+                'id': 'host_explicit_group_2',
+                'name': 'host3',
+                'memoryallocated': 0,
+                'clusterid': '1',
+                'affinitygroupid': 'e2',
+                'requiresStorageMotion': False,
+                'suitableformigration': True
+            }, {
+                'id': 'host_explicit_group_1',
+                'name': 'host4',
+                'memoryallocated': 0,
+                'clusterid': '1',
+                'affinitygroupid': 'e1',
+                'requiresStorageMotion': False,
+                'suitableformigration': True
+            }, {
+                'id': 'host_normal',
+                'name': 'host5',
+                'memoryallocated': 0,
+                'clusterid': '1',
+                'requiresStorageMotion': False,
+                'suitableformigration': True
+            }]
+        }
+
+    def test_refresh(self):
+        self.host.refresh()
+        self.cs_instance.listHosts.assert_called_with(id='h1')
+
+    def test_disable(self):
+        def refresh_effect():
+            self.host._host['resourcestate'] = 'Enabled' if self.host.refresh.call_count == 1 else 'Disabled'
+
+        self.host.refresh = Mock(side_effect=refresh_effect)
+        self.assertTrue(self.host.disable())
+        self.cs_instance.updateHost.assert_called_with(id='h1', allocationstate='Disable')
+
+    def test_disable_dry_run(self):
+        self.host.dry_run = True
+        self.assertTrue(self.host.disable())
+        self.cs_instance.updateHost.assert_not_called()
+
+    def test_disable_failure(self):
+        self.host.refresh = Mock()
+        self.cs_instance.updateHost.return_value = {}
+        self.assertFalse(self.host.disable())
+
+    def test_enable(self):
+        def refresh_effect():
+            self.host._host['resourcestate'] = 'Disabled' if self.host.refresh.call_count == 1 else 'Enabled'
+
+        self.host.refresh = Mock(side_effect=refresh_effect)
+        self.assertTrue(self.host.enable())
+        self.cs_instance.updateHost.assert_called_with(id='h1', allocationstate='Enable')
+
+    def test_enable_dry_run(self):
+        self.host.dry_run = True
+        self.assertTrue(self.host.enable())
+        self.cs_instance.updateHost.assert_not_called()
+
+    def test_enable_failure(self):
+        self.host.refresh = Mock()
+        self.cs_instance.updateHost.return_value = {}
+        self.assertFalse(self.host.enable())
+
+    def test_empty(self):
+        self._mock_hosts_and_vms()
+        self.assertEqual((4, 4, 0), self.host.empty())
+        self.user_vm.stop.assert_not_called()
+
+        for vm in self.all_vms:
+            self.assertEqual('host_normal', vm.migrate.call_args[0][0]['id'])
+
+    def test_empty_dry_run(self):
+        self.host._ops.dry_run = True
+        self.host.dry_run = True
+        self._mock_hosts_and_vms()
+
+        self.assertEqual((4, 4, 0), self.host.empty())
+        self.cs_instance.stopVirtualMachine.assert_not_called()
+        self.cs_instance.detachIso.assert_not_called()
+        self.cs_instance.migrateVirtualMachine.assert_not_called()
+        self.cs_instance.migrateSystemVm.assert_not_called()
+
+    def test_empty_on_empty_host(self):
+        self.host.get_all_vms = Mock(return_value=None)
+        self.assertEqual((0, 0, 0), self.host.empty())
+
+    def test_empty_with_shutdown_and_start_policy(self):
+        self.user_vm._vm['maintenancepolicy'] = 'ShutdownAndStart'
+        self._mock_hosts_and_vms()
+
+        self.assertEqual((4, 4, 0), self.host.empty())
+        self.user_vm.stop.assert_called_once()
+        self.assertEqual('v1', self.host.vms_with_shutdown_policy[0]['id'])
+
+    def test_empty_with_shutdown_and_start_policy_and_failed_shutdown(self):
+        self.user_vm._vm['maintenancepolicy'] = 'ShutdownAndStart'
+        self._mock_hosts_and_vms()
+        self.user_vm.stop.return_value = False
+
+        self.assertEqual((4, 3, 1), self.host.empty())
+
+        self.user_vm.stop.assert_called_once()
+        self.assertEqual('v1', self.host.vms_with_shutdown_policy[0]['id'])
+
+    def test_empty_with_affinity_group(self):
+        self._mock_hosts_and_vms()
+        self.user_vm.get_affinity_groups.return_value = [{
+            'id': 'e1',
+            'name': 'explicit1',
+            'type': 'ExplicitDedication',
+            'virtualmachineIds': ['v1']
+        }]
+
+        self.assertEqual((4, 4, 0), self.host.empty())
+        self.assertEqual('host_explicit_group_1', self.user_vm.migrate.call_args[0][0]['id'])
+
+    def test_empty_with_requires_storage_motion(self):
+        self._mock_hosts_and_vms()
+        self.cs_instance.findHostsForMigration.return_value = {
+            'host': [{
+                'id': 'h2',
+                'name': 'host2',
+                'memoryallocated': 0,
+                'clusterid': '1',
+                'requiresStorageMotion': True,
+                'suitableformigration': True,
+            }, {
+                'id': 'h3',
+                'name': 'host3',
+                'memoryallocated': 0,
+                'clusterid': '1',
+                'requiresStorageMotion': False,
+                'suitableformigration': True,
+            }]
+        }
+
+        self.assertEqual((4, 4, 0), self.host.empty())
+        self.assertEqual('h3', self.user_vm.migrate.call_args[0][0]['id'])
+
+    def test_empty_with_different_cluster(self):
+        self._mock_hosts_and_vms()
+        self.cs_instance.findHostsForMigration.return_value = {
+            'host': [{
+                'id': 'h2',
+                'name': 'host2',
+                'memoryallocated': 0,
+                'clusterid': '2',
+                'requiresStorageMotion': False,
+                'suitableformigration': True,
+            }, {
+                'id': 'h3',
+                'name': 'host3',
+                'memoryallocated': 0,
+                'clusterid': '1',
+                'requiresStorageMotion': False,
+                'suitableformigration': True,
+            }]
+        }
+
+        self.assertEqual((4, 4, 0), self.host.empty())
+        self.assertEqual('h3', self.user_vm.migrate.call_args[0][0]['id'])
+
+    def test_empty_with_unsuitable_host(self):
+        self._mock_hosts_and_vms()
+        self.cs_instance.findHostsForMigration.return_value = {
+            'host': [{
+                'id': 'h2',
+                'name': 'host2',
+                'memoryallocated': 0,
+                'clusterid': '1',
+                'requiresStorageMotion': False,
+                'suitableformigration': False,
+            }, {
+                'id': 'h3',
+                'name': 'host3',
+                'memoryallocated': 0,
+                'clusterid': '1',
+                'requiresStorageMotion': False,
+                'suitableformigration': True,
+            }]
+        }
+
+        self.assertEqual((4, 4, 0), self.host.empty())
+        self.assertEqual('h3', self.user_vm.migrate.call_args[0][0]['id'])
+
+    def test_empty_without_migration_host(self):
+        self._mock_hosts_and_vms()
+        self.cs_instance.findHostsForMigration.return_value = {}
+
+        self.assertEqual((4, 0, 4), self.host.empty())
+        self.assertEqual(4, self.cs_instance.findHostsForMigration.call_count)
+
+        for vm in self.all_vms:
+            vm.migrate.assert_not_called()
+
+    def test_empty_with_migrate_virtual_machine_failure(self):
+        self._mock_hosts_and_vms()
+        self.user_vm.migrate.return_value = False
+        self.assertEqual((4, 3, 1), self.host.empty())
+
+    def test_empty_with_migrate_system_vm_failure(self):
+        self._mock_hosts_and_vms()
+        self.secondary_storage_vm.migrate.return_value = False
+        self.console_proxy.migrate.return_value = False
+        self.assertEqual((4, 2, 2), self.host.empty())
+
+    def test_get_all_vms(self):
+        self._mock_cosmic_vm_calls()
+        self.host.get_all_vms()
+
+        self.cs_instance.listVirtualMachines.assert_has_calls([call(hostid='h1', listall='true'),
+                                                               call(hostid='h1', listall='true', projectid='-1')], True)
+        self.cs_instance.listRouters.assert_has_calls([call(hostid='h1', listall='true'),
+                                                       call(hostid='h1', listall='true', projectid='-1')], True)
+        self.cs_instance.listSystemVms.assert_called_with(hostid='h1')
+
+    def test_copy_file(self):
+        self.host.copy_file('src', 'dst')
+        self.connection_instance.put.assert_called_with('src', 'dst')
+
+        self.host.copy_file('src', 'dst', 0o644)
+        self.connection_instance.sudo.assert_called_with('chmod 644 dst')
+
+    def test_copy_file_dry_run(self):
+        self.host.dry_run = True
+
+        self.host.copy_file('src', 'dst')
+        self.connection_instance.put.assert_not_called()
+
+    def test_execute(self):
+        self.host.execute('cmd')
+        self.connection_instance.run.assert_called_with('cmd')
+
+        self.host.execute('cmd', True)
+        self.connection_instance.sudo.assert_called_with('cmd')
+
+    def test_execute_dry_run(self):
+        self.host.dry_run = True
+
+        self.host.execute('cmd')
+        self.connection_instance.run.assert_not_called()
+        self.connection_instance.sudo.assert_not_called()
+
+    def test_reboot(self):
+        self.host.execute = Mock()
+        self.host.execute.return_value.stdout = '0\n'
+
+        self.assertTrue(self.host.reboot())
+        self.host.execute.assert_called_with('shutdown -r 1', sudo=True)
+        self.assertTrue(self.host.reboot(RebootAction.HALT))
+        self.host.execute.assert_called_with('shutdown -h 1', sudo=True)
+        self.assertTrue(self.host.reboot(RebootAction.FORCE_RESET))
+        self.host.execute.assert_has_calls([call('sync', sudo=True), call('echo b > /proc/sysrq-trigger', sudo=True)])
+        self.assertTrue(self.host.reboot(RebootAction.UPGRADE_FIRMWARE))
+        self.host.execute.assert_called_with("tmux new -d 'yes | sudo /usr/sbin/smartupdate upgrade && sudo reboot'")
+        self.assertTrue(self.host.reboot(RebootAction.SKIP))
+        self.host.execute.assert_called_with('virsh list | grep running | wc -l')
+
+    def test_reboot_with_running_vms(self):
+        self.host.execute = Mock()
+        self.host.execute.return_value.stdout = '3\n'
+
+        self.assertFalse(self.host.reboot())
+
+    def test_reboot_exception(self):
+        self.host.execute = Mock()
+        self.host.execute.side_effect = [Mock(stdout='0\n'), Exception]
+        self.assertTrue(self.host.reboot())
+
+    def test_reboot_dry_run(self):
+        self.host.dry_run = True
+        self.host.execute = Mock()
+
+        self.assertTrue(self.host.reboot())
+        self.host.execute.assert_not_called()
+
+    def test_wait_until_offline(self):
+        self.socket_context.connect_ex.side_effect = [0, 1]
+
+        self.host.wait_until_offline()
+        self.socket_context.connect_ex.assert_called_with(('host1', 22))
+
+    def test_wait_until_offline_dry_run(self):
+        self.host.dry_run = True
+
+        self.host.wait_until_offline()
+        self.socket_context.connect_ex.assert_not_called()
+
+    def test_wait_until_online(self):
+        self.host.execute = Mock()
+        self.host.execute.side_effect = [Mock(return_code=1), Mock(return_code=0)]
+        self.socket_context.connect_ex.side_effect = [1, 0]
+
+        self.host.wait_until_online()
+        self.socket_context.connect_ex.assert_called_with(('host1', 22))
+        self.host.execute.assert_called_with('virsh list')
+
+    def test_wait_until_online_dry_run(self):
+        self.host.dry_run = True
+        self.host.execute = Mock()
+
+        self.host.wait_until_online()
+        self.socket_context.connect_ex.assert_not_called()
+        self.host.execute.assert_not_called()
+
+    def test_wait_for_agent(self):
+        def refresh_effect():
+            self.host._host['state'] = 'Disconnected' if self.host.refresh.call_count == 1 else 'Up'
+
+        self.host.refresh = Mock(side_effect=refresh_effect)
+
+        self.host.wait_for_agent()
+        self.assertEqual(2, self.host.refresh.call_count)
+
+    def test_wait_for_agent_dry_run(self):
+        self.host.dry_run = True
+        self.host.refresh = Mock()
+
+        self.host.wait_for_agent()
+        self.host.refresh.assert_not_called()
+
+    def _mock_vms_with_shutdown_policy(self):
+        self.host.vms_with_shutdown_policy = [
+            CosmicVM(self.ops, {'id': 'vm1', 'name': 'vm1'}),
+            CosmicVM(self.ops, {'id': 'vm2', 'name': 'vm2'})
+        ]
+        self.host._ops.wait_for_job = Mock(side_effect=[False, True])
+
+    def test_restart_vms_with_shutdown_policy(self):
+        self._mock_vms_with_shutdown_policy()
+
+        self.host.restart_vms_with_shutdown_policy()
+        self.cs_instance.startVirtualMachine.assert_has_calls([call(id='vm1'), call(id='vm2')], True)
+
+    def test_restart_vms_with_shutdown_policy_dry_run(self):
+        self.host._ops.dry_run = True
+        self.host.dry_run = True
+        self._mock_vms_with_shutdown_policy()
+
+        self.host.restart_vms_with_shutdown_policy()
+        self.cs_instance.startVirtualMachine.assert_not_called()

--- a/tests/test_cosmicops.py
+++ b/tests/test_cosmicops.py
@@ -1,0 +1,147 @@
+# Copyright 2020, Schuberg Philis B.V
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from cs import CloudStackException
+from requests.exceptions import ConnectionError
+from testfixtures import tempdir
+
+from cosmicops import CosmicOps
+from cosmicops.ops import load_cloud_monkey_profile
+
+
+class TestCosmicOps(TestCase):
+    def setUp(self):
+        cs_patcher = patch('cosmicops.ops.CloudStack')
+        self.mock_cs = cs_patcher.start()
+        self.addCleanup(cs_patcher.stop)
+        self.cs_instance = self.mock_cs.return_value
+
+        sleep_patcher = patch('time.sleep', return_value=None)
+        self.mock_sleep = sleep_patcher.start()
+        self.addCleanup(sleep_patcher.stop)
+
+        self.co = CosmicOps(endpoint='https://localhost', key='key', secret='secret')
+
+    @patch('cosmicops.ops.load_cloud_monkey_profile')
+    def test_init_with_profile(self, mock_load):
+        mock_load.return_value = ('profile_endpoint', 'profile_key', 'profile_secret')
+        CosmicOps(profile='config')
+        self.mock_cs.assert_called_with('profile_endpoint', 'profile_key', 'profile_secret', 60)
+
+    @tempdir()
+    def test_load_cloud_monkey_profile(self, tmp):
+        config = (b"[testprofile]\n"
+                  b"url = http://localhost:8000/client/api\n"
+                  b"apikey = test_api_key\n"
+                  b"secretkey = test_secret_key\n"
+                  )
+
+        tmp.makedir('.cloudmonkey')
+        tmp.write('.cloudmonkey/config', config)
+        with patch('pathlib.Path.home') as path_home_mock:
+            path_home_mock.return_value = Path(tmp.path)
+            (endpoint, key, secret) = load_cloud_monkey_profile('testprofile')
+
+        self.assertEqual('http://localhost:8000/client/api', endpoint)
+        self.assertEqual('test_api_key', key)
+        self.assertEqual('test_secret_key', secret)
+
+    @tempdir()
+    def test_load_cloud_monkey_profile_with_default(self, tmp):
+        config = (b"[core]\n"
+                  b"profile = profile2\n\n"
+                  b"[profile1]\n"
+                  b"url = http://localhost:8000/client/api/1\n"
+                  b"apikey = test_api_key_1\n"
+                  b"secretkey = test_secret_key_1\n\n"
+                  b"[profile2]\n"
+                  b"url = http://localhost:8000/client/api/2\n"
+                  b"apikey = test_api_key_2\n"
+                  b"secretkey = test_secret_key_2\n"
+                  )
+
+        tmp.makedir('.cloudmonkey')
+        tmp.write('.cloudmonkey/config', config)
+        with patch('pathlib.Path.home') as path_home_mock:
+            path_home_mock.return_value = Path(tmp.path)
+            (endpoint, key, secret) = load_cloud_monkey_profile('config')
+
+        self.assertEqual('http://localhost:8000/client/api/2', endpoint)
+        self.assertEqual('test_api_key_2', key)
+        self.assertEqual('test_secret_key_2', secret)
+
+    def test_get_host_by_name(self):
+        self.cs_instance.listHosts.return_value = {
+            'host': [{
+                'id': 'h1',
+                'name': 'host1',
+                'clusterid': '1'
+            }]
+        }
+
+        result = self.co.get_host_by_name('host1')
+        self.assertEqual(('h1', 'host1', '1'), (result['id'], result['name'], result['clusterid']))
+
+    def test_get_host_by_name_failure(self):
+        self.cs_instance.listHosts.return_value = {'host': []}
+        self.assertIsNone(self.co.get_host_by_name('host1'))
+
+        self.cs_instance.listHosts.return_value = {'host': [{}, {}]}
+        self.assertIsNone(self.co.get_host_by_name('host1'))
+
+    def test_get_cluster_by_name(self):
+        self.cs_instance.listClusters.return_value = {
+            'cluster': [{
+                'id': 'c1',
+                'name': 'cluster1'
+            }]
+        }
+
+        result = self.co.get_cluster_by_name('cluster1')
+        self.assertEqual(('c1', 'cluster1'), (result['id'], result['name']))
+
+    def test_get_cluster_by_name_failure(self):
+        self.cs_instance.listClusters.return_value = {'cluster': []}
+        self.assertIsNone(self.co.get_cluster_by_name('cluster1'))
+
+        self.cs_instance.listClusters.return_value = {'cluster': [{}, {}]}
+        self.assertIsNone(self.co.get_cluster_by_name('cluster1'))
+
+    def test_wait_for_job(self):
+        self.cs_instance.queryAsyncJobResult.return_value = {'jobstatus': '1'}
+        self.assertTrue(self.co.wait_for_job('job'))
+
+    def test_wait_for_job_cloud_stack_exception(self):
+        self.cs_instance.queryAsyncJobResult.side_effect = CloudStackException(response=Mock())
+        self.assertRaises(CloudStackException, self.co.wait_for_job, 'job')
+
+    def test_wait_for_job_connection_error(self):
+        self.cs_instance.queryAsyncJobResult.side_effect = ConnectionError
+        self.assertRaises(ConnectionError, self.co.wait_for_job, 'job')
+
+    def test_wait_for_job_retries(self):
+        self.cs_instance.queryAsyncJobResult.side_effect = [
+            CloudStackException('multiple JSON fields named jobstatus', response=Mock()),
+            ConnectionError('Connection aborted'),
+            ConnectionError('Connection aborted')
+        ]
+        self.assertFalse(self.co.wait_for_job('job', 3))
+
+    def test_wait_for_job_failure(self):
+        self.cs_instance.queryAsyncJobResult.return_value = {'jobstatus': '2'}
+        self.assertFalse(self.co.wait_for_job('job'))

--- a/tests/test_cosmicsql.py
+++ b/tests/test_cosmicsql.py
@@ -1,0 +1,116 @@
+# Copyright 2020, Schuberg Philis B.V
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import configparser
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import patch, call
+
+import mariadb
+from testfixtures import tempdir
+
+from cosmicops import CosmicSQL
+
+
+class TestCosmicSQL(TestCase):
+    def setUp(self):
+        mariadb_connect_patcher = patch('mariadb.connect')
+        self.mock_connect = mariadb_connect_patcher.start()
+        self.addCleanup(mariadb_connect_patcher.stop)
+        self.mock_cursor = self.mock_connect.return_value.cursor.return_value
+
+        self.cs = CosmicSQL(server='localhost', password='password')
+
+    @tempdir()
+    def test_load_from_config(self, tmp):
+        config = (b"[testmariadb]\n"
+                  b"host = 10.0.0.1\n"
+                  b"port = 3706\n"
+                  b"user = test_user\n"
+                  b"password = test_password\n"
+                  )
+
+        tmp.write('config', config)
+        with patch('pathlib.Path.cwd') as path_cwd_mock:
+            path_cwd_mock.return_value = Path(tmp.path)
+            cs = CosmicSQL(server='testmariadb')
+
+        self.assertEqual('10.0.0.1', cs.server)
+        self.assertEqual(3706, cs.port)
+        self.assertEqual('test_user', cs.user)
+        self.assertEqual('test_password', cs.password)
+
+        with patch('pathlib.Path.cwd') as path_cwd_mock:
+            path_cwd_mock.return_value = Path(tmp.path)
+            self.assertRaises(RuntimeError, CosmicSQL, server='dummy')
+
+    @tempdir()
+    def test_load_from_config_with_defaults(self, tmp):
+        config = (b"[testmariadb]\n"
+                  b"password = test_password\n"
+                  )
+
+        tmp.write('config', config)
+        with patch('pathlib.Path.cwd') as path_cwd_mock:
+            path_cwd_mock.return_value = Path(tmp.path)
+            cs = CosmicSQL(server='testmariadb')
+
+        self.assertEqual('testmariadb', cs.server)
+        self.assertEqual(3306, cs.port)
+        self.assertEqual('cloud', cs.user)
+        self.assertEqual('test_password', cs.password)
+
+    @tempdir()
+    def test_load_from_config_without_password(self, tmp):
+        config = (b"[testmariadb]\n"
+                  b"host = 10.0.0.1\n"
+                  )
+
+        tmp.write('config', config)
+        with patch('pathlib.Path.cwd') as path_cwd_mock:
+            path_cwd_mock.return_value = Path(tmp.path)
+            self.assertRaises(configparser.NoOptionError, CosmicSQL, server='testmariadb')
+
+    def test_connect_failure(self):
+        self.mock_connect.side_effect = mariadb.Error('Mock connection error')
+        self.assertRaises(mariadb.Error, CosmicSQL, server='localhost', password='password')
+
+    def test_kill_jobs_of_instance(self):
+        self.assertTrue(self.cs.kill_jobs_of_instance('i-1-VM'))
+
+        self.mock_cursor.execute.assert_has_calls([
+            call('DELETE FROM `async_job` WHERE `instance_id` = ?', ('i-1-VM',)),
+            call('DELETE FROM `vm_work_job` WHERE `vm_instance_id` = ?', ('i-1-VM',)),
+            call('DELETE FROM `sync_queue` WHERE `sync_objid` = ?', ('i-1-VM',))
+        ])
+        self.assertEqual(3, self.mock_cursor.commit.call_count)
+        self.mock_cursor.close.assert_called_once()
+
+    def test_kill_jobs_of_instance_dry_run(self):
+        self.cs = CosmicSQL(server='localhost', password='password', dry_run=True)
+
+        self.assertTrue(self.cs.kill_jobs_of_instance('i-1-VM'))
+
+        self.mock_cursor.execute.assert_has_calls([
+            call('DELETE FROM `async_job` WHERE `instance_id` = ?', ('i-1-VM',)),
+            call('DELETE FROM `vm_work_job` WHERE `vm_instance_id` = ?', ('i-1-VM',)),
+            call('DELETE FROM `sync_queue` WHERE `sync_objid` = ?', ('i-1-VM',))
+        ])
+        self.mock_cursor.commit.assert_not_called()
+        self.mock_cursor.close.assert_called_once()
+
+    def test_kill_jobs_of_instance_query_failure(self):
+        self.mock_cursor.execute.side_effect = mariadb.Error('Mock query error')
+
+        self.assertFalse(self.cs.kill_jobs_of_instance('i-1-VM'))
+        self.mock_cursor.close.assert_called_once()

--- a/tests/test_cosmicvm.py
+++ b/tests/test_cosmicvm.py
@@ -1,0 +1,115 @@
+# Copyright 2020, Schuberg Philis B.V
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from cs import CloudStackException
+
+from cosmicops import CosmicOps, CosmicVM, CosmicHost
+
+
+class TestCosmicVM(TestCase):
+    def setUp(self):
+        cs_patcher = patch('cosmicops.ops.CloudStack')
+        self.mock_cs = cs_patcher.start()
+        self.addCleanup(cs_patcher.stop)
+        self.cs_instance = self.mock_cs.return_value
+
+        sleep_patcher = patch('time.sleep', return_value=None)
+        self.mock_sleep = sleep_patcher.start()
+        self.addCleanup(sleep_patcher.stop)
+
+        self._vm_json = {
+            'id': 'v1',
+            'name': 'vm1',
+            'instancename': 'i-1-VM',
+            'hostname': 'host1',
+            'maintenancepolicy': 'LiveMigrate',
+            'isoid': 'iso1'
+        }
+
+        self.ops = CosmicOps(endpoint='https://localhost', key='key', secret='secret')
+        self.ops.wait_for_job = Mock(return_value=True)
+        self.vm = CosmicVM(self.ops, self._vm_json)
+        self.target_host = CosmicHost(self.ops, {'id': 'h1', 'name': 'host1'})
+
+    def test_stop(self):
+        self.assertTrue(self.vm.stop())
+        self.ops.cs.stopVirtualMachine.assert_called_with(id=self.vm['id'])
+
+    def test_stop_dry_run(self):
+        self.vm.dry_run = True
+        self.assertTrue(self.vm.stop())
+        self.ops.cs.stopVirtualMachine.assert_not_called()
+
+    def test_stop_failure(self):
+        self.vm._ops.wait_for_job = Mock(return_value=False)
+        self.assertFalse(self.vm.stop())
+
+    def test_start(self):
+        self.assertTrue(self.vm.start())
+        self.ops.cs.startVirtualMachine.assert_called_with(id=self.vm['id'])
+
+    def test_start_dry_run(self):
+        self.vm.dry_run = True
+        self.assertTrue(self.vm.start())
+        self.ops.cs.startVirtualMachine.assert_not_called()
+
+    def test_start_failure(self):
+        self.vm._ops.wait_for_job = Mock(return_value=False)
+        self.assertFalse(self.vm.start())
+
+    def test_get_affinity_groups(self):
+        self.cs_instance.listAffinityGroups.return_value = {'affinitygroup': [{'id': 'a1'}]}
+        self.assertEqual([{'id': 'a1'}], self.vm.get_affinity_groups())
+
+    def test_get_affinity_groups_exception(self):
+        self.cs_instance.listAffinityGroups.side_effect = CloudStackException(response=Mock())
+        self.assertEqual([], self.vm.get_affinity_groups())
+
+    def test_migrate(self):
+        self.assertTrue(self.vm.migrate(self.target_host))
+        self.cs_instance.detachIso.assert_called_with(virtualmachineid=self.vm['id'])
+        self.cs_instance.migrateVirtualMachine.assert_called_with(virtualmachineid=self.vm['id'],
+                                                                  hostid=self.target_host['id'])
+        self.cs_instance.migrateSystemVm.assert_not_called()
+
+    def test_migrate_dry_run(self):
+        self.vm.dry_run = True
+        self.assertTrue(self.vm.migrate(self.target_host))
+        self.cs_instance.detachIso.assert_not_called()
+        self.cs_instance.migrateVirtualMachine.assert_not_called()
+        self.cs_instance.migrateSystemVm.assert_not_called()
+
+    def test_migrate_systemvm(self):
+        del (self.vm._vm['instancename'])
+        self.assertTrue(self.vm.migrate(self.target_host))
+        self.cs_instance.detachIso.assert_not_called()
+        self.cs_instance.migrateVirtualMachine.assert_not_called()
+        self.cs_instance.migrateSystemVm.assert_called_with(virtualmachineid=self.vm['id'],
+                                                            hostid=self.target_host['id'])
+
+    def test_migrate_with_migrate_virtual_machine_failure(self):
+        self.cs_instance.migrateVirtualMachine.return_value = None
+        self.assertFalse(self.vm.migrate(self.target_host))
+
+    def test_migrate_with_migrate_system_vm_failure(self):
+        del (self.vm._vm['instancename'])
+        self.cs_instance.migrateSystemVm.return_value = None
+        self.assertFalse(self.vm.migrate(self.target_host))
+
+    def test_migrate_with_job_failure(self):
+        self.vm._ops.wait_for_job = Mock(return_value=False)
+        self.assertFalse(self.vm.migrate(self.target_host))

--- a/tests/test_empty_host.py
+++ b/tests/test_empty_host.py
@@ -1,0 +1,56 @@
+# Copyright 2020, Schuberg Philis B.V
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from click.testing import CliRunner
+
+import empty_host
+
+
+class TestEmptyHost(TestCase):
+    def setUp(self):
+        co_patcher = patch('empty_host.CosmicOps')
+        self.co = co_patcher.start()
+        self.addCleanup(co_patcher.stop)
+        self.co_instance = self.co.return_value
+        self.runner = CliRunner()
+
+    def test_main(self):
+        host_mock = Mock()
+        host_mock.empty.return_value = (1, 1, 0)
+        self.co_instance.get_host_by_name.return_value = host_mock
+
+        result = self.runner.invoke(empty_host.main, ['host1'])
+        self.co.assert_called_with(profile='config', dry_run=False)
+        self.co_instance.get_host_by_name.assert_called_with('host1')
+        host_mock.empty.assert_called()
+        self.assertEqual(0, result.exit_code)
+
+    def test_fail_on_empty_host_response(self):
+        self.co_instance.get_host_by_name.return_value = []
+
+        result = self.runner.invoke(empty_host.main, ['host1'])
+        self.co_instance.get_host_by_name.assert_called_with('host1')
+        self.assertEqual(1, result.exit_code)
+
+    def test_dry_run(self):
+        host_mock = Mock()
+        host_mock.empty.return_value = (1, 1, 0)
+        self.co_instance.get_host_by_name.return_value = host_mock
+
+        result = self.runner.invoke(empty_host.main, ['--dry-run', 'host1'])
+        self.co.assert_called_with(profile='config', dry_run=True)
+        self.assertEqual(0, result.exit_code)

--- a/tests/test_kill_jobs.py
+++ b/tests/test_kill_jobs.py
@@ -1,0 +1,41 @@
+# Copyright 2020, Schuberg Philis B.V
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import TestCase
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+import kill_jobs
+
+
+class TestKillJobs(TestCase):
+    def setUp(self):
+        cs_patcher = patch('kill_jobs.CosmicSQL')
+        self.cs = cs_patcher.start()
+        self.addCleanup(cs_patcher.stop)
+        self.cs_instance = self.cs.return_value
+        self.runner = CliRunner()
+
+    def test_main(self):
+        result = self.runner.invoke(kill_jobs.main, ['-s', 'server_address', '-p', 'password', 'i-1-VM'])
+        self.cs.assert_called_with(server='server_address', port=3306, user='cloud', password='password', dry_run=False)
+        self.cs_instance.kill_jobs_of_instance.assert_called_with('i-1-VM')
+        self.assertEqual(0, result.exit_code)
+
+    def test_dry_run(self):
+        result = self.runner.invoke(kill_jobs.main, ['-s', 'server_address', '-p', 'password', '-n', 'i-1-VM'])
+        self.cs.assert_called_with(server='server_address', port=3306, user='cloud', password='password', dry_run=True)
+
+        self.assertEqual(0, result.exit_code)

--- a/tests/test_rolling_reboot.py
+++ b/tests/test_rolling_reboot.py
@@ -1,0 +1,186 @@
+# Copyright 2020, Schuberg Philis B.V
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import TestCase
+from unittest.mock import Mock, patch, call
+
+from click.testing import CliRunner
+
+import rolling_reboot
+from cosmicops.host import RebootAction, CosmicHost
+
+
+class TestRollingReboot(TestCase):
+    def setUp(self):
+        co_patcher = patch('rolling_reboot.CosmicOps')
+        self.co = co_patcher.start()
+        self.addCleanup(co_patcher.stop)
+        self.co_instance = self.co.return_value
+
+        sleep_patcher = patch('time.sleep', return_value=None)
+        self.mock_sleep = sleep_patcher.start()
+        self.addCleanup(sleep_patcher.stop)
+
+        self.runner = CliRunner()
+
+    def _mock_cluster_with_hosts(self):
+        self.cluster = Mock()
+        self.co_instance.get_cluster_by_name.return_value = self.cluster
+
+        self.hosts = []
+        for i in range(3):
+            host = CosmicHost(Mock(), {
+                'id': f'h{i}',
+                'name': f'host{i}',
+                'clusterid': 'c1',
+                'state': 'Up',
+                'resourcestate': 'Enabled'
+            })
+            host.empty = Mock(return_value=(0, 0, 0))
+            host.disable = Mock(return_value=True)
+            host.enable = Mock(return_value=True)
+            host.reboot = Mock(return_value=True)
+            host.wait_until_offline = Mock(return_value=None)
+            host.wait_until_online = Mock(return_value=None)
+            host.copy_file = Mock(return_value=None)
+            host.execute = Mock(return_value=None)
+
+            self.hosts.append(host)
+
+        self.cluster.get_all_hosts.return_value = self.hosts
+
+    def test_main(self):
+        self._mock_cluster_with_hosts()
+
+        result = self.runner.invoke(rolling_reboot.main, ['cluster1'])
+        self.assertEqual(0, result.exit_code)
+
+        self.co.assert_called_with(profile='config', dry_run=False)
+        self.co_instance.get_cluster_by_name.assert_called_with('cluster1')
+
+        self.cluster.get_all_hosts.assert_called()
+
+        for host in self.hosts:
+            host.disable.assert_called()
+            host.reboot.assert_called_with(RebootAction.REBOOT)
+            host.wait_until_offline.assert_called()
+            host.wait_until_online.assert_called()
+            host.enable.assert_called()
+
+    def test_ignore_hosts(self):
+        self._mock_cluster_with_hosts()
+
+        result = self.runner.invoke(rolling_reboot.main, ['--ignore-hosts', 'host2', 'cluster1'])
+        self.assertEqual(0, result.exit_code)
+
+        self.hosts[0].reboot.assert_called_with(RebootAction.REBOOT)
+        self.hosts[1].reboot.assert_called_with(RebootAction.REBOOT)
+        self.hosts[2].reboot.assert_not_called()
+
+    def test_only_hosts(self):
+        self._mock_cluster_with_hosts()
+
+        result = self.runner.invoke(rolling_reboot.main, ['--only-hosts', 'host1,host2', 'cluster1'])
+        self.assertEqual(0, result.exit_code)
+
+        self.hosts[0].reboot.assert_not_called()
+        self.hosts[1].reboot.assert_called_with(RebootAction.REBOOT)
+        self.hosts[2].reboot.assert_called_with(RebootAction.REBOOT)
+
+    def test_skip_os_version(self):
+        self._mock_cluster_with_hosts()
+        self.hosts[0]._host['hypervisorversion'] = 'CentOS 7.5.1804'
+        self.hosts[1]._host['hypervisorversion'] = 'CentOS 7.7.1908'
+        self.hosts[2]._host['hypervisorversion'] = 'CentOS 8.0.1905'
+
+        result = self.runner.invoke(rolling_reboot.main, ['--skip-os-version', 'CentOS 7', 'cluster1'])
+        self.assertEqual(0, result.exit_code)
+
+        self.hosts[0].reboot.assert_not_called()
+        self.hosts[1].reboot.assert_not_called()
+        self.hosts[2].reboot.assert_called_with(RebootAction.REBOOT)
+
+    def test_scripts(self):
+        self._mock_cluster_with_hosts()
+
+        result = self.runner.invoke(rolling_reboot.main, ['--pre-empty-script', 'pre_empty_script.sh',
+                                                          '--post-empty-script', 'post_empty_script.sh',
+                                                          '--post-reboot-script', 'post_reboot_script.sh',
+                                                          'cluster1'])
+        self.assertEqual(0, result.exit_code)
+
+        for host in self.hosts:
+            host.copy_file.assert_has_calls([call('pre_empty_script.sh', '/tmp/pre_empty_script.sh', mode=0o755),
+                                             call('post_empty_script.sh', '/tmp/post_empty_script.sh', mode=0o755),
+                                             call('post_reboot_script.sh', '/tmp/post_reboot_script.sh', mode=0o755)])
+            host.execute.assert_has_calls([call('/tmp/pre_empty_script.sh', sudo=True),
+                                           call('/tmp/post_empty_script.sh', sudo=True),
+                                           call('/tmp/post_reboot_script.sh', sudo=True)])
+
+    def test_failures(self):
+        # Cluster lookup failure
+        self.co_instance.get_cluster_by_name.return_value = None
+
+        result = self.runner.invoke(rolling_reboot.main, ['cluster1'])
+        self.assertEqual(1, result.exit_code)
+
+        # Host disable failure
+        self._mock_cluster_with_hosts()
+        self.hosts[0].disable = Mock(return_value=False)
+        result = self.runner.invoke(rolling_reboot.main, ['cluster1'])
+        self.assertEqual(1, result.exit_code)
+
+        self.hosts[0].disable.assert_called()
+
+        # Host disconnected
+        self._mock_cluster_with_hosts()
+        self.hosts[0]._host['state'] = 'Disconnected'
+        result = self.runner.invoke(rolling_reboot.main, ['cluster1'])
+        self.assertEqual(1, result.exit_code)
+
+        self.hosts[0].disable.assert_called()
+
+        # Test if script continues after host empty failure
+        self._mock_cluster_with_hosts()
+        self.hosts[0].empty = Mock(side_effect=[(5, 0, 5), (5, 5, 0)])
+        result = self.runner.invoke(rolling_reboot.main, ['cluster1'])
+        self.assertEqual(0, result.exit_code)
+
+        self.hosts[0].empty.assert_called()
+        self.hosts[0].reboot.assert_called()
+        self.hosts[1].reboot.assert_called()
+        self.hosts[2].reboot.assert_called()
+
+        # Host reboot failure
+        self._mock_cluster_with_hosts()
+        self.hosts[0].reboot = Mock(return_value=False)
+        result = self.runner.invoke(rolling_reboot.main, ['cluster1'])
+        self.assertEqual(1, result.exit_code)
+
+        self.hosts[0].reboot.assert_called()
+
+        # Host enable failure
+        self._mock_cluster_with_hosts()
+        self.hosts[0].enable = Mock(return_value=False)
+        result = self.runner.invoke(rolling_reboot.main, ['cluster1'])
+        self.assertEqual(1, result.exit_code)
+
+        self.hosts[0].enable.assert_called()
+
+    def test_dry_run(self):
+        self._mock_cluster_with_hosts()
+
+        result = self.runner.invoke(rolling_reboot.main, ['--dry-run', 'cluster1'])
+        self.assertEqual(0, result.exit_code)
+        self.co.assert_called_with(profile='config', dry_run=True)


### PR DESCRIPTION
Pulling in scripts from cloudstackOps, while cleaning them up and porting to Python 3.

Note that command line arguments have changed, the output has changed and the default behaviour is to execute instead of dry-run.