### PR TITLE
Add basic System VM support with stop/start/destroy

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,25 +15,25 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [ 3.6, 3.7, 3.8 ]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        sudo apt-get install -y libmariadb3 libmariadb-dev
-        python -m pip install --upgrade pip
-        pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-    - name: Test with pytest
-      run: |
-        pytest
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          sudo apt-get install -y libmariadb3 libmariadb-dev
+          python -m pip install --upgrade pip
+          pip install flake8 pytest
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      - name: Test with pytest
+        run: |
+          pytest
 

--- a/cosmicops/__init__.py
+++ b/cosmicops/__init__.py
@@ -16,6 +16,7 @@ from .cluster import CosmicCluster
 from .host import CosmicHost
 from .ops import CosmicOps
 from .sql import CosmicSQL
+from .systemvm import CosmicSystemVM
 from .vm import CosmicVM
 
-__all__ = [CosmicOps, CosmicSQL, CosmicHost, CosmicCluster, CosmicVM]
+__all__ = [CosmicOps, CosmicSQL, CosmicHost, CosmicCluster, CosmicVM, CosmicSystemVM]

--- a/cosmicops/ops.py
+++ b/cosmicops/ops.py
@@ -23,6 +23,7 @@ from requests.exceptions import ConnectionError
 
 from .cluster import CosmicCluster
 from .host import CosmicHost
+from .systemvm import CosmicSystemVM
 
 
 def load_cloud_monkey_profile(profile):
@@ -76,6 +77,30 @@ class CosmicOps(object):
             return None
 
         return CosmicCluster(self, response[0])
+
+    def get_systemvm_by_name(self, systemvm_name):
+        response = self.cs.listSystemVms(name=systemvm_name).get('systemvm')
+
+        if not response:
+            logging.error(f"System VM '{systemvm_name}' not found")
+            return None
+        elif len(response) != 1:
+            logging.error(f"Lookup for system VM '{systemvm_name}' returned multiple results")
+            return None
+
+        return CosmicSystemVM(self, response[0])
+
+    def get_systemvm_by_id(self, systemvm_id):
+        response = self.cs.listSystemVms(id=systemvm_id).get('systemvm')
+
+        if not response:
+            logging.error(f"System VM with ID '{systemvm_id}' not found")
+            return None
+        elif len(response) != 1:
+            logging.error(f"Lookup for system VM with ID '{systemvm_id}' returned multiple results")
+            return None
+
+        return CosmicSystemVM(self, response[0])
 
     def wait_for_job(self, job_id, retries=10):
         job_status = 0

--- a/cosmicops/systemvm.py
+++ b/cosmicops/systemvm.py
@@ -1,0 +1,72 @@
+# Copyright 2020, Schuberg Philis B.V
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from collections.abc import Mapping
+
+
+class CosmicSystemVM(Mapping):
+    def __init__(self, ops, vm):
+        self._ops = ops
+        self._vm = vm
+        self.dry_run = ops.dry_run
+
+    def __getitem__(self, item):
+        return self._vm[item]
+
+    def __iter__(self):
+        return iter(self._vm)
+
+    def __len__(self):
+        return len(self._vm)
+
+    def stop(self):
+        if self.dry_run:
+            logging.info(
+                f"Would shut down system VM '{self['name']}' on host '{self['hostname']}'")
+            return True
+
+        logging.info(f"Stopping system VM '{self['name']}'")
+        response = self._ops.cs.stopSystemVm(id=self['id'])
+        if not self._ops.wait_for_job(response['jobid']):
+            logging.error(f"Failed to shutdown system VM '{self['name']}' on host '{self['hostname']}'")
+            return False
+
+        return True
+
+    def start(self):
+        if self.dry_run:
+            logging.info(f"Would start system VM '{self['name']}")
+            return True
+
+        logging.info(f"Starting system VM '{self['name']}'")
+        response = self._ops.cs.startSystemVm(id=self['id'])
+        if not self._ops.wait_for_job(response['jobid']):
+            logging.error(f"Failed to start system VM '{self['name']}'")
+            return False
+
+        return True
+
+    def destroy(self):
+        if self.dry_run:
+            logging.info(f"Would destroy system VM '{self['name']}'")
+            return True
+
+        logging.info(f"Destroying system VM '{self['name']}'")
+        response = self._ops.cs.destroySystemVm(id=self['id'])
+        if not self._ops.wait_for_job(response['jobid']):
+            logging.error(f"Failed to destroy system VM '{self['name']}'")
+            return False
+
+        return True

--- a/tests/test_cosmicops.py
+++ b/tests/test_cosmicops.py
@@ -122,6 +122,42 @@ class TestCosmicOps(TestCase):
         self.cs_instance.listClusters.return_value = {'cluster': [{}, {}]}
         self.assertIsNone(self.co.get_cluster_by_name('cluster1'))
 
+    def test_get_systemvm_by_name(self):
+        self.cs_instance.listSystemVms.return_value = {
+            'systemvm': [{
+                'id': 'svm1',
+                'name': 's-1-VM'
+            }]
+        }
+
+        result = self.co.get_systemvm_by_name('s-1-VM')
+        self.assertEqual(('svm1', 's-1-VM'), (result['id'], result['name']))
+
+    def test_get_systemvm_by_name_failure(self):
+        self.cs_instance.listSystemVms.return_value = {'systemvm': []}
+        self.assertIsNone(self.co.get_systemvm_by_name('s-1-VM'))
+
+        self.cs_instance.listSystemVms.return_value = {'systemvm': [{}, {}]}
+        self.assertIsNone(self.co.get_systemvm_by_name('s-1-VM'))
+
+    def test_get_systemvm_by_id(self):
+        self.cs_instance.listSystemVms.return_value = {
+            'systemvm': [{
+                'id': 'svm1',
+                'name': 's-1-VM'
+            }]
+        }
+
+        result = self.co.get_systemvm_by_id('svm1')
+        self.assertEqual(('svm1', 's-1-VM'), (result['id'], result['name']))
+
+    def test_get_systemvm_by_id_failure(self):
+        self.cs_instance.listSystemVms.return_value = {'systemvm': []}
+        self.assertIsNone(self.co.get_systemvm_by_id('svm1'))
+
+        self.cs_instance.listSystemVms.return_value = {'systemvm': [{}, {}]}
+        self.assertIsNone(self.co.get_systemvm_by_id('svm1'))
+
     def test_wait_for_job(self):
         self.cs_instance.queryAsyncJobResult.return_value = {'jobstatus': '1'}
         self.assertTrue(self.co.wait_for_job('job'))

--- a/tests/test_cosmicsystemvm.py
+++ b/tests/test_cosmicsystemvm.py
@@ -1,0 +1,80 @@
+# Copyright 2020, Schuberg Philis B.V
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from cosmicops import CosmicOps, CosmicSystemVM, CosmicHost
+
+
+class TestCosmicSystemVM(TestCase):
+    def setUp(self):
+        cs_patcher = patch('cosmicops.ops.CloudStack')
+        self.mock_cs = cs_patcher.start()
+        self.addCleanup(cs_patcher.stop)
+        self.cs_instance = self.mock_cs.return_value
+
+        sleep_patcher = patch('time.sleep', return_value=None)
+        self.mock_sleep = sleep_patcher.start()
+        self.addCleanup(sleep_patcher.stop)
+
+        self._systemvm_json = {
+            'id': 'svm1',
+            'name': 's-1-VM',
+            'hostname': 'host1'
+        }
+
+        self.ops = CosmicOps(endpoint='https://localhost', key='key', secret='secret')
+        self.ops.wait_for_job = Mock(return_value=True)
+        self.systemvm = CosmicSystemVM(self.ops, self._systemvm_json)
+        self.target_host = CosmicHost(self.ops, {'id': 'h1', 'name': 'host1'})
+
+    def test_stop(self):
+        self.assertTrue(self.systemvm.stop())
+        self.ops.cs.stopSystemVm.assert_called_with(id=self.systemvm['id'])
+
+    def test_stop_dry_run(self):
+        self.systemvm.dry_run = True
+        self.assertTrue(self.systemvm.stop())
+        self.ops.cs.stopSystemVm.assert_not_called()
+
+    def test_stop_failure(self):
+        self.systemvm._ops.wait_for_job = Mock(return_value=False)
+        self.assertFalse(self.systemvm.stop())
+
+    def test_start(self):
+        self.assertTrue(self.systemvm.start())
+        self.ops.cs.startSystemVm.assert_called_with(id=self.systemvm['id'])
+
+    def test_start_dry_run(self):
+        self.systemvm.dry_run = True
+        self.assertTrue(self.systemvm.start())
+        self.ops.cs.startSystemVm.assert_not_called()
+
+    def test_start_failure(self):
+        self.systemvm._ops.wait_for_job = Mock(return_value=False)
+        self.assertFalse(self.systemvm.start())
+
+    def test_destroy(self):
+        self.assertTrue(self.systemvm.destroy())
+        self.ops.cs.destroySystemVm.assert_called_with(id=self.systemvm['id'])
+
+    def test_destroy_dry_run(self):
+        self.systemvm.dry_run = True
+        self.assertTrue(self.systemvm.destroy())
+        self.ops.cs.destroySystemVm.assert_not_called()
+
+    def test_destroy_failure(self):
+        self.systemvm._ops.wait_for_job = Mock(return_value=False)
+        self.assertFalse(self.systemvm.destroy())


### PR DESCRIPTION
Usage:

```
from cosmicops import CosmicOps
co = CosmicOps(profile='bubble')
svm1 = co.get_systemvm_by_name('s-1-VM')
svm2 = co.get_systemvm_by_id('73f0427e-4097-4b0d-a051-bb158b2288ba')

svm1.stop()
svm1.start()
svm1.destroy()
```