### PR TITLE
Add custom logging module to support Slack

### DIFF
--- a/config.example
+++ b/config.example
@@ -1,3 +1,6 @@
+[slack]
+hookurl = https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
+
 [mariadb-alias]
 host = localhost
 database = cloud

--- a/cosmicops/__init__.py
+++ b/cosmicops/__init__.py
@@ -14,9 +14,10 @@
 
 from .cluster import CosmicCluster
 from .host import CosmicHost
+from .log import logging
 from .ops import CosmicOps
 from .sql import CosmicSQL
 from .systemvm import CosmicSystemVM
 from .vm import CosmicVM
 
-__all__ = [CosmicOps, CosmicSQL, CosmicHost, CosmicCluster, CosmicVM, CosmicSystemVM]
+__all__ = [CosmicOps, CosmicSQL, CosmicHost, CosmicCluster, CosmicVM, CosmicSystemVM, logging]

--- a/cosmicops/log.py
+++ b/cosmicops/log.py
@@ -1,0 +1,120 @@
+# Copyright 2020, Schuberg Philis B.V
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging as logging_module
+from configparser import ConfigParser
+from logging import DEBUG, WARNING, ERROR, INFO
+from pathlib import Path
+
+from slack_webhook import Slack
+
+
+class CosmicLog(object):
+    def __init__(self):
+        self._slack = self._configure_slack()
+        self.slack_title = 'Undefined'
+        self.slack_value = 'Undefined'
+        self.task = 'Undefined'
+        self.instance_name = 'Undefined'
+        self.vm_name = 'Undefined'
+        self.cluster = 'Undefined'
+        self.zone_name = 'Undefined'
+
+    @staticmethod
+    def _configure_slack():
+        config_file = Path.cwd() / 'config'
+        config = ConfigParser()
+        config.read(str(config_file))
+
+        slack_hook_url = config.get('slack', 'hookurl', fallback=None)
+
+        if slack_hook_url:
+            return Slack(url=slack_hook_url)
+        else:
+            print(f"warning: No Slack connection details found in '{config_file}'")
+            return None
+
+    def _log(self, log_level, message, to_slack):
+        logging_module.log(log_level, message)
+
+        if to_slack and self._slack:
+            if log_level == ERROR:
+                color = 'danger'
+            elif log_level == WARNING:
+                color = 'warning'
+            else:
+                color = 'good'
+
+            self._send_slack_message(message, color)
+
+    def _send_slack_message(self, message, color='good'):
+        attachments = []
+        attachment = {'text': message, 'color': color, 'mrkdwn_in': ['text', 'pretext', 'fields'], 'mrkdwn': 'true',
+                      'fields': [
+                          {
+                              'title': str(self.slack_title),
+                              'value': str(self.slack_value),
+                              'short': 'true'
+                          },
+                          {
+                              'title': 'Task',
+                              'value': self.task,
+                              'short': 'true'
+                          },
+                          {
+                              'title': 'Cluster',
+                              'value': self.cluster,
+                              'short': 'true'
+                          },
+                          {
+                              'title': 'Instance ID',
+                              'value': self.instance_name,
+                              'short': 'true'
+                          },
+                          {
+                              'title': 'VM name',
+                              'value': self.vm_name,
+                              'short': 'true'
+                          },
+                          {
+                              'title': 'Zone',
+                              'value': self.zone_name,
+                              'short': 'true'
+                          }
+                      ]}
+
+        try:
+            attachments.append(attachment)
+            self._slack.post(attachments=attachments, icon_emoji=':robot_face:', username='cosmicOps')
+        except:
+            print('warning: Slack post failed.')
+
+    @staticmethod
+    def getLogger():
+        return logging_module.getLogger()
+
+    def info(self, message, to_slack=False):
+        self._log(INFO, message, to_slack)
+
+    def debug(self, message, to_slack=False):
+        self._log(DEBUG, message, to_slack)
+
+    def warning(self, message, to_slack=False):
+        self._log(WARNING, message, to_slack)
+
+    def error(self, message, to_slack=False):
+        self._log(ERROR, message, to_slack)
+
+
+logging = CosmicLog()

--- a/cosmicops/log.py
+++ b/cosmicops/log.py
@@ -14,6 +14,7 @@
 
 import logging as logging_module
 from configparser import ConfigParser
+from datetime import datetime
 from logging import DEBUG, WARNING, ERROR, INFO
 from pathlib import Path
 
@@ -62,6 +63,10 @@ class CosmicLog(object):
         attachments = []
         attachment = {'text': message, 'color': color, 'mrkdwn_in': ['text', 'pretext', 'fields'], 'mrkdwn': 'true',
                       'fields': [
+                          {
+                              'title': 'Timestamp',
+                              'value': datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+                          },
                           {
                               'title': str(self.slack_title),
                               'value': str(self.slack_value),

--- a/cosmicops/ops.py
+++ b/cosmicops/ops.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import time
 from configparser import ConfigParser
 from pathlib import Path
@@ -23,10 +22,11 @@ from requests.exceptions import ConnectionError
 
 from .cluster import CosmicCluster
 from .host import CosmicHost
+from .log import logging
 from .systemvm import CosmicSystemVM
 
 
-def load_cloud_monkey_profile(profile):
+def _load_cloud_monkey_profile(profile):
     config_file = Path.home() / '.cloudmonkey' / 'config'
     config = ConfigParser()
     config.read(str(config_file))
@@ -39,16 +39,17 @@ def load_cloud_monkey_profile(profile):
 
 
 class CosmicOps(object):
-    def __init__(self, endpoint=None, key=None, secret=None, profile=None, timeout=60, dry_run=True):
+    def __init__(self, endpoint=None, key=None, secret=None, profile=None, timeout=60, dry_run=True,
+                 log_to_slack=False):
         if profile:
-            (endpoint, key, secret) = load_cloud_monkey_profile(profile)
+            (endpoint, key, secret) = _load_cloud_monkey_profile(profile)
 
         self.endpoint = endpoint
         self.key = key
         self.secret = secret
-
         self.timeout = timeout
         self.dry_run = dry_run
+        self.log_to_slack = log_to_slack
         self.cs = CloudStack(self.endpoint, self.key, self.secret, self.timeout)
 
     def get_host_by_name(self, host_name):

--- a/cosmicops/sql.py
+++ b/cosmicops/sql.py
@@ -18,6 +18,8 @@ from pathlib import Path
 
 import pymysql
 
+from .log import logging
+
 
 class CosmicSQL(object):
     def __init__(self, server, port=3306, password=None, user='cloud', database='cloud', dry_run=True):

--- a/cosmicops/systemvm.py
+++ b/cosmicops/systemvm.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 from collections.abc import Mapping
+
+from .log import logging
 
 
 class CosmicSystemVM(Mapping):

--- a/cosmicops/vm.py
+++ b/cosmicops/vm.py
@@ -23,6 +23,7 @@ class CosmicVM(Mapping):
     def __init__(self, ops, vm):
         self._ops = ops
         self._vm = vm
+        self.log_to_slack = ops.log_to_slack
         self.dry_run = ops.dry_run
 
     def __getitem__(self, item):
@@ -36,11 +37,15 @@ class CosmicVM(Mapping):
 
     def stop(self):
         if self.dry_run:
-            logging.info(
-                f"Would shut down VM '{self['name']}' on host '{self['hostname']}' as it has a ShutdownAndStart policy")
+            logging.info(f"Would stop VM '{self['name']} on host '{self['hostname']}'")
             return True
 
-        logging.info(f"Stopping VM '{self['name']}'")
+        if self.get('maintenancepolicy') == 'ShutdownAndStart':
+            logging.info(
+                f"Stopping VM '{self['name']}' on host '{self['hostname']}' as it has a ShutdownAndStart policy",
+                self.log_to_slack)
+        else:
+            logging.info(f"Stopping VM '{self['name']}' on host '{self['hostname']}'", self.log_to_slack)
         stop_response = self._ops.cs.stopVirtualMachine(id=self['id'])
         if not self._ops.wait_for_job(stop_response['jobid']):
             logging.error(f"Failed to shutdown VM '{self['name']}' on host '{self['hostname']}'")
@@ -50,10 +55,10 @@ class CosmicVM(Mapping):
 
     def start(self):
         if self.dry_run:
-            logging.info(f"Would start VM '{self['name']}")
+            logging.info(f"Would start VM '{self['name']} on host '{self['hostname']}'")
             return True
 
-        logging.info(f"Starting VM '{self['name']}'")
+        logging.info(f"Starting VM '{self['name']}' on host '{self['hostname']}'", self.log_to_slack)
         start_response = self._ops.cs.startVirtualMachine(id=self['id'])
         if not self._ops.wait_for_job(start_response['jobid']):
             logging.error(f"Failed to start VM '{self['name']}'")
@@ -76,7 +81,7 @@ class CosmicVM(Mapping):
             return True
 
         try:
-            logging.info(f"Live migrating VM '{self['name']}' to '{target_host['name']}'")
+            logging.info(f"Live migrating VM '{self['name']}' to '{target_host['name']}'", self.log_to_slack)
 
             if 'instancename' in self:
                 if 'isoid' in self:

--- a/cosmicops/vm.py
+++ b/cosmicops/vm.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 from collections.abc import Mapping
 
 from cs import CloudStackException
+
+from .log import logging
 
 
 class CosmicVM(Mapping):

--- a/empty_host.py
+++ b/empty_host.py
@@ -13,13 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import sys
 
 import click
 import click_log
 
-from cosmicops import CosmicOps
+from cosmicops import CosmicOps, logging
 
 
 @click.command()

--- a/kill_jobs.py
+++ b/kill_jobs.py
@@ -13,12 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-
 import click
 import click_log
 
-from cosmicops import CosmicSQL
+from cosmicops import CosmicSQL, logging
 
 
 @click.command()

--- a/list_ha_workers.py
+++ b/list_ha_workers.py
@@ -13,14 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import sys
 
 import click
 import click_log
 from tabulate import tabulate
 
-from cosmicops import CosmicSQL
+from cosmicops import CosmicSQL, logging
 
 
 @click.command()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ cs~=3.0.0
 fabric~=2.5.0
 PyMySQL~=0.8.0
 requests~=2.24.0
+slack-webhook~=1.0.3
 testfixtures~=6.14.1
 tabulate~=0.8.7

--- a/tests/test_cosmichost.py
+++ b/tests/test_cosmichost.py
@@ -36,6 +36,10 @@ class TestCosmicHost(TestCase):
         self.addCleanup(socket_patcher.stop)
         self.socket_context = self.mock_socket.return_value.__enter__.return_value
 
+        slack_patcher = patch('cosmicops.log.Slack')
+        self.mock_slack = slack_patcher.start()
+        self.addCleanup(slack_patcher.stop)
+
         sleep_patcher = patch('time.sleep', return_value=None)
         self.mock_sleep = sleep_patcher.start()
         self.addCleanup(sleep_patcher.stop)
@@ -472,8 +476,10 @@ class TestCosmicHost(TestCase):
 
     def _mock_vms_with_shutdown_policy(self):
         self.host.vms_with_shutdown_policy = [
-            CosmicVM(self.ops, {'id': 'vm1', 'name': 'vm1'}),
-            CosmicVM(self.ops, {'id': 'vm2', 'name': 'vm2'})
+            CosmicVM(self.ops,
+                     {'id': 'vm1', 'name': 'vm1', 'hostname': 'host1', 'maintenancepolicy': 'ShutdownAndStart'}),
+            CosmicVM(self.ops,
+                     {'id': 'vm2', 'name': 'vm2', 'hostname': 'host1', 'maintenancepolicy': 'ShutdownAndStart'})
         ]
         self.host._ops.wait_for_job = Mock(side_effect=[False, True])
 

--- a/tests/test_cosmiclogging.py
+++ b/tests/test_cosmiclogging.py
@@ -78,13 +78,13 @@ class TestCosmicLog(TestCase):
         attachment_fields = attachment['fields']
         self.assertEqual('test_message', attachment['text'])
         self.assertEqual('good', attachment['color'])
-        self.assertEqual('test_title', attachment_fields[0]['title'])
-        self.assertEqual('test_value', attachment_fields[0]['value'])
-        self.assertEqual('test_task', attachment_fields[1]['value'])
-        self.assertEqual('test_cluster', attachment_fields[2]['value'])
-        self.assertEqual('test_instance_name', attachment_fields[3]['value'])
-        self.assertEqual('test_vm_name', attachment_fields[4]['value'])
-        self.assertEqual('test_zone_name', attachment_fields[5]['value'])
+        self.assertEqual('test_title', attachment_fields[1]['title'])
+        self.assertEqual('test_value', attachment_fields[1]['value'])
+        self.assertEqual('test_task', attachment_fields[2]['value'])
+        self.assertEqual('test_cluster', attachment_fields[3]['value'])
+        self.assertEqual('test_instance_name', attachment_fields[4]['value'])
+        self.assertEqual('test_vm_name', attachment_fields[5]['value'])
+        self.assertEqual('test_zone_name', attachment_fields[6]['value'])
         self.assertEqual('cosmicOps', call_args[1]['username'])
 
     def test_send_slack_message_failure(self):

--- a/tests/test_cosmiclogging.py
+++ b/tests/test_cosmiclogging.py
@@ -1,0 +1,94 @@
+# Copyright 2020, Schuberg Philis B.V
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import patch, Mock
+
+from testfixtures import tempdir
+
+from cosmicops.log import CosmicLog, WARNING, ERROR, INFO
+
+
+class TestCosmicLog(TestCase):
+    def setUp(self):
+        slack_patcher = patch('cosmicops.log.Slack')
+        self.mock_slack = slack_patcher.start()
+        self.addCleanup(slack_patcher.stop)
+        self.slack_instance = self.mock_slack.return_value
+
+        self.logging = CosmicLog()
+
+    @tempdir()
+    def test_load_from_config(self, tmp):
+        config = (b"[slack]\n"
+                  b"hookurl = https://test.url/slack/hook\n"
+                  )
+
+        tmp.write('config', config)
+        with patch('pathlib.Path.cwd') as path_cwd_mock:
+            path_cwd_mock.return_value = Path(tmp.path)
+            self.assertEqual(self.slack_instance, self.logging._configure_slack())
+
+        self.mock_slack.assert_called_with(url='https://test.url/slack/hook')
+
+        with patch('pathlib.Path.cwd') as path_cwd_mock:
+            path_cwd_mock.return_value = Path('/dev/null')
+            self.assertIsNone(self.logging._configure_slack())
+
+    def test_log_to_slack(self):
+        send_message_mock = Mock()
+        self.logging._send_slack_message = send_message_mock
+        self.logging._slack = self.slack_instance
+
+        self.logging._log(INFO, 'info message', True)
+        send_message_mock.assert_called_with('info message', 'good')
+
+        self.logging._log(WARNING, 'warning message', True)
+        send_message_mock.assert_called_with('warning message', 'warning')
+
+        self.logging._log(ERROR, 'error message', True)
+        send_message_mock.assert_called_with('error message', 'danger')
+
+    def test_send_slack_message(self):
+        self.logging._slack = self.slack_instance
+        self.logging.slack_title = 'test_title'
+        self.logging.slack_value = 'test_value'
+        self.logging.task = 'test_task'
+        self.logging.cluster = 'test_cluster'
+        self.logging.instance_name = 'test_instance_name'
+        self.logging.vm_name = 'test_vm_name'
+        self.logging.zone_name = 'test_zone_name'
+
+        self.logging._send_slack_message('test_message')
+
+        call_args = self.slack_instance.post.call_args
+        attachment = call_args[1]['attachments'][0]
+        attachment_fields = attachment['fields']
+        self.assertEqual('test_message', attachment['text'])
+        self.assertEqual('good', attachment['color'])
+        self.assertEqual('test_title', attachment_fields[0]['title'])
+        self.assertEqual('test_value', attachment_fields[0]['value'])
+        self.assertEqual('test_task', attachment_fields[1]['value'])
+        self.assertEqual('test_cluster', attachment_fields[2]['value'])
+        self.assertEqual('test_instance_name', attachment_fields[3]['value'])
+        self.assertEqual('test_vm_name', attachment_fields[4]['value'])
+        self.assertEqual('test_zone_name', attachment_fields[5]['value'])
+        self.assertEqual('cosmicOps', call_args[1]['username'])
+
+    def test_send_slack_message_failure(self):
+        self.slack_instance.post.side_effect = RuntimeError
+        self.logging._slack = self.slack_instance
+
+        self.logging._send_slack_message('test_message_failure')

--- a/tests/test_cosmicops.py
+++ b/tests/test_cosmicops.py
@@ -31,6 +31,10 @@ class TestCosmicOps(TestCase):
         self.addCleanup(cs_patcher.stop)
         self.cs_instance = self.mock_cs.return_value
 
+        slack_patcher = patch('cosmicops.log.Slack')
+        self.mock_slack = slack_patcher.start()
+        self.addCleanup(slack_patcher.stop)
+
         sleep_patcher = patch('time.sleep', return_value=None)
         self.mock_sleep = sleep_patcher.start()
         self.addCleanup(sleep_patcher.stop)

--- a/tests/test_cosmicops.py
+++ b/tests/test_cosmicops.py
@@ -21,7 +21,7 @@ from requests.exceptions import ConnectionError
 from testfixtures import tempdir
 
 from cosmicops import CosmicOps
-from cosmicops.ops import load_cloud_monkey_profile
+from cosmicops.ops import _load_cloud_monkey_profile
 
 
 class TestCosmicOps(TestCase):
@@ -37,7 +37,7 @@ class TestCosmicOps(TestCase):
 
         self.co = CosmicOps(endpoint='https://localhost', key='key', secret='secret')
 
-    @patch('cosmicops.ops.load_cloud_monkey_profile')
+    @patch('cosmicops.ops._load_cloud_monkey_profile')
     def test_init_with_profile(self, mock_load):
         mock_load.return_value = ('profile_endpoint', 'profile_key', 'profile_secret')
         CosmicOps(profile='config')
@@ -55,7 +55,7 @@ class TestCosmicOps(TestCase):
         tmp.write('.cloudmonkey/config', config)
         with patch('pathlib.Path.home') as path_home_mock:
             path_home_mock.return_value = Path(tmp.path)
-            (endpoint, key, secret) = load_cloud_monkey_profile('testprofile')
+            (endpoint, key, secret) = _load_cloud_monkey_profile('testprofile')
 
         self.assertEqual('http://localhost:8000/client/api', endpoint)
         self.assertEqual('test_api_key', key)
@@ -79,7 +79,7 @@ class TestCosmicOps(TestCase):
         tmp.write('.cloudmonkey/config', config)
         with patch('pathlib.Path.home') as path_home_mock:
             path_home_mock.return_value = Path(tmp.path)
-            (endpoint, key, secret) = load_cloud_monkey_profile('config')
+            (endpoint, key, secret) = _load_cloud_monkey_profile('config')
 
         self.assertEqual('http://localhost:8000/client/api/2', endpoint)
         self.assertEqual('test_api_key_2', key)

--- a/tests/test_cosmicsystemvm.py
+++ b/tests/test_cosmicsystemvm.py
@@ -25,6 +25,10 @@ class TestCosmicSystemVM(TestCase):
         self.addCleanup(cs_patcher.stop)
         self.cs_instance = self.mock_cs.return_value
 
+        slack_patcher = patch('cosmicops.log.Slack')
+        self.mock_slack = slack_patcher.start()
+        self.addCleanup(slack_patcher.stop)
+
         sleep_patcher = patch('time.sleep', return_value=None)
         self.mock_sleep = sleep_patcher.start()
         self.addCleanup(sleep_patcher.stop)

--- a/tests/test_cosmicvm.py
+++ b/tests/test_cosmicvm.py
@@ -27,6 +27,10 @@ class TestCosmicVM(TestCase):
         self.addCleanup(cs_patcher.stop)
         self.cs_instance = self.mock_cs.return_value
 
+        slack_patcher = patch('cosmicops.log.Slack')
+        self.mock_slack = slack_patcher.start()
+        self.addCleanup(slack_patcher.stop)
+
         sleep_patcher = patch('time.sleep', return_value=None)
         self.mock_sleep = sleep_patcher.start()
         self.addCleanup(sleep_patcher.stop)

--- a/tests/test_empty_host.py
+++ b/tests/test_empty_host.py
@@ -26,6 +26,11 @@ class TestEmptyHost(TestCase):
         self.co = co_patcher.start()
         self.addCleanup(co_patcher.stop)
         self.co_instance = self.co.return_value
+
+        slack_patcher = patch('cosmicops.log.Slack')
+        self.mock_slack = slack_patcher.start()
+        self.addCleanup(slack_patcher.stop)
+
         self.runner = CliRunner()
 
     def test_main(self):

--- a/tests/test_rolling_reboot.py
+++ b/tests/test_rolling_reboot.py
@@ -28,6 +28,10 @@ class TestRollingReboot(TestCase):
         self.addCleanup(co_patcher.stop)
         self.co_instance = self.co.return_value
 
+        slack_patcher = patch('cosmicops.log.Slack')
+        self.mock_slack = slack_patcher.start()
+        self.addCleanup(slack_patcher.stop)
+
         sleep_patcher = patch('time.sleep', return_value=None)
         self.mock_sleep = sleep_patcher.start()
         self.addCleanup(sleep_patcher.stop)

--- a/tests/test_rolling_reboot.py
+++ b/tests/test_rolling_reboot.py
@@ -45,8 +45,10 @@ class TestRollingReboot(TestCase):
                 'name': f'host{i}',
                 'clusterid': 'c1',
                 'state': 'Up',
-                'resourcestate': 'Enabled'
+                'resourcestate': 'Enabled',
+                'zonename': 'zone1'
             })
+            host.get_all_vms = Mock(return_value=[1, 2, 3])
             host.empty = Mock(return_value=(0, 0, 0))
             host.disable = Mock(return_value=True)
             host.enable = Mock(return_value=True)
@@ -66,7 +68,7 @@ class TestRollingReboot(TestCase):
         result = self.runner.invoke(rolling_reboot.main, ['--exec', 'cluster1'])
         self.assertEqual(0, result.exit_code)
 
-        self.co.assert_called_with(profile='config', dry_run=False)
+        self.co.assert_called_with(profile='config', dry_run=False, log_to_slack=True)
         self.co_instance.get_cluster_by_name.assert_called_with('cluster1')
 
         self.cluster.get_all_hosts.assert_called()
@@ -184,4 +186,4 @@ class TestRollingReboot(TestCase):
 
         result = self.runner.invoke(rolling_reboot.main, ['cluster1'])
         self.assertEqual(0, result.exit_code)
-        self.co.assert_called_with(profile='config', dry_run=True)
+        self.co.assert_called_with(profile='config', dry_run=True, log_to_slack=False)


### PR DESCRIPTION
* Add a very minimal wrapper for `logging` with the functions we use
* Update the test cases
* Update the example config
* Copy some log messages from the `cloudstackOps` rolling reboot script