### PR TITLE
Some small fixes for rolling_reboot.py

### DIFF
--- a/cosmicops/host.py
+++ b/cosmicops/host.py
@@ -222,7 +222,7 @@ class CosmicHost(Mapping):
         if mode:
             self._connection.sudo(f'chmod {mode:o} {destination}')
 
-    def execute(self, command, sudo=False):
+    def execute(self, command, sudo=False, hide_stdout=True):
         if self.dry_run:
             logging.info(f"Would execute '{command}' on '{self['name']}")
             return
@@ -232,7 +232,7 @@ class CosmicHost(Mapping):
         else:
             runner = self._connection.run
 
-        return runner(command, hide=True)
+        return runner(command, hide=hide_stdout)
 
     def reboot(self, action=RebootAction.REBOOT):
         if self.dry_run:

--- a/cosmicops/host.py
+++ b/cosmicops/host.py
@@ -20,6 +20,7 @@ from operator import itemgetter
 
 import click_spinner
 import paramiko
+from cs import CloudStackApiException
 from fabric import Connection
 from invoke import UnexpectedExit, CommandTimedOut
 
@@ -47,7 +48,7 @@ class CosmicHost(Mapping):
         self.dry_run = ops.dry_run
 
         # Patch Fabric connection to use different host policy (see https://github.com/fabric/fabric/issues/2071)
-        def unsafe_open(self):
+        def unsafe_open(self):  # pragma: no cover
             self.client.set_missing_host_key_policy(paramiko.MissingHostKeyPolicy())
             Connection.open_orig(self)
 
@@ -151,7 +152,13 @@ class CosmicHost(Mapping):
                     vm_on_dedicated_hv = True
                     dedicated_affinity_id = affinity_group['id']
 
-            available_hosts = self._ops.cs.findHostsForMigration(virtualmachineid=vm['id']).get('host', [])
+            try:
+                available_hosts = self._ops.cs.findHostsForMigration(virtualmachineid=vm['id']).get('host', [])
+            except CloudStackApiException as e:
+                logging.error(f"Encountered API exception while finding suitable host for migration: {e}")
+                failed += 1
+                continue
+
             available_hosts.sort(key=itemgetter('memoryallocated'))
             migration_host = None
 

--- a/rolling_reboot.py
+++ b/rolling_reboot.py
@@ -101,7 +101,7 @@ def main(profile, ignore_hosts, only_hosts, skip_os_version, reboot_action, pre_
             host.copy_file(str(path), f'/tmp/{path.name}', mode=0o755)
 
         if pre_empty_script:
-            host.execute(f'/tmp/{Path(pre_empty_script).name}', sudo=True)
+            host.execute(f'/tmp/{Path(pre_empty_script).name}', sudo=True, hide_stdout=False)
 
         if host['resourcestate'] != 'Disabled':
             if not host.disable():
@@ -127,7 +127,7 @@ def main(profile, ignore_hosts, only_hosts, skip_os_version, reboot_action, pre_
         logging.info(f"Host {host['name']} is empty", log_to_slack)
 
         if post_empty_script:
-            host.execute(f'/tmp/{Path(post_empty_script).name}', sudo=True)
+            host.execute(f'/tmp/{Path(post_empty_script).name}', sudo=True, hide_stdout=False)
 
         if not host.reboot(reboot_action):
             sys.exit(1)
@@ -137,7 +137,7 @@ def main(profile, ignore_hosts, only_hosts, skip_os_version, reboot_action, pre_
             host.wait_until_online()
 
         if post_reboot_script:
-            host.execute(f'/tmp/{Path(post_reboot_script).name}', sudo=True)
+            host.execute(f'/tmp/{Path(post_reboot_script).name}', sudo=True, hide_stdout=False)
 
         if not host.enable():
             sys.exit(1)

--- a/tests/test_cosmichost.py
+++ b/tests/test_cosmichost.py
@@ -15,6 +15,7 @@
 from unittest import TestCase
 from unittest.mock import Mock, patch, call
 
+from cs import CloudStackApiException
 from invoke import UnexpectedExit, CommandTimedOut
 
 from cosmicops import CosmicOps, CosmicHost, CosmicVM
@@ -364,6 +365,13 @@ class TestCosmicHost(TestCase):
 
         for vm in self.all_vms:
             vm.migrate.assert_not_called()
+
+    def test_empty_with_find_hosts_for_migration_failure(self):
+        self._mock_hosts_and_vms()
+        self.cs_instance.findHostsForMigration.side_effect = CloudStackApiException('HTTP 431 response from CloudStack',
+                                                                                    error='Mock error', response=Mock())
+
+        self.assertEqual((4, 0, 4), self.host.empty())
 
     def test_empty_with_migrate_virtual_machine_failure(self):
         self._mock_hosts_and_vms()

--- a/tests/test_rolling_reboot.py
+++ b/tests/test_rolling_reboot.py
@@ -131,9 +131,9 @@ class TestRollingReboot(TestCase):
             host.copy_file.assert_has_calls([call('pre_empty_script.sh', '/tmp/pre_empty_script.sh', mode=0o755),
                                              call('post_empty_script.sh', '/tmp/post_empty_script.sh', mode=0o755),
                                              call('post_reboot_script.sh', '/tmp/post_reboot_script.sh', mode=0o755)])
-            host.execute.assert_has_calls([call('/tmp/pre_empty_script.sh', sudo=True),
-                                           call('/tmp/post_empty_script.sh', sudo=True),
-                                           call('/tmp/post_reboot_script.sh', sudo=True)])
+            host.execute.assert_has_calls([call('/tmp/pre_empty_script.sh', sudo=True, hide_stdout=False),
+                                           call('/tmp/post_empty_script.sh', sudo=True, hide_stdout=False),
+                                           call('/tmp/post_reboot_script.sh', sudo=True, hide_stdout=False)])
 
     def test_failures(self):
         # Cluster lookup failure


### PR DESCRIPTION
* Show stdout for the pre empty, post empty and post reboot scripts
* Handle API exceptions thrown by findHostsForMigration