### PR TITLE
Bundle of small fixes

### DIFF
--- a/cosmicops/host.py
+++ b/cosmicops/host.py
@@ -183,8 +183,8 @@ class CosmicHost(CosmicObject):
                             f"Skipping '{available_host['name']}' because host does not match the dedication group of VM '{vm['name']}'")
                         continue
                 else:
-                    # VM isn't dedicated, so skip dedicated hosts
-                    if 'affinitygroupid' in available_host:
+                    # If the user VM isn't dedicated, skip dedicated hosts
+                    if vm.is_user_vm() and 'affinitygroupid' in available_host:
                         logging.info(
                             f"Skipping '{available_host['name']}' because host is dedicated and VM '{vm['name']}' is not")
                         continue

--- a/cosmicops/vm.py
+++ b/cosmicops/vm.py
@@ -79,6 +79,9 @@ class CosmicVM(CosmicObject):
         if 'isoid' in self:
             self._ops.cs.detachIso(virtualmachineid=self['id'])
 
+    def is_user_vm(self):
+        return True if 'instancename' in self else False
+
     def migrate(self, target_host, with_volume=False):
         if self.dry_run:
             logging.info(f"Would live migrate VM '{self['name']}' to '{target_host['name']}'")
@@ -92,7 +95,7 @@ class CosmicVM(CosmicObject):
         try:
             logging.info(f"Live migrating VM '{self['name']}' to '{target_host['name']}'", self.log_to_slack)
 
-            if 'instancename' in self:
+            if self.is_user_vm():
                 self.detach_iso()
 
                 vm_result = migrate_func(virtualmachineid=self['id'], hostid=target_host['id'])

--- a/cosmicops/vm.py
+++ b/cosmicops/vm.py
@@ -43,17 +43,17 @@ class CosmicVM(CosmicObject):
 
     def start(self, host=None):
         if host:
-            hostname = host['name']
             host_id = host['id']
+            on_host_msg = f" on host '{host['name']}'"
         else:
-            hostname = self['hostname']
             host_id = None
+            on_host_msg = ''
 
         if self.dry_run:
-            logging.info(f"Would start VM '{self['name']} on host '{hostname}'")
+            logging.info(f"Would start VM '{self['name']}{on_host_msg}")
             return True
 
-        logging.info(f"Starting VM '{self['name']}' on host '{hostname}'", self.log_to_slack)
+        logging.info(f"Starting VM '{self['name']}'{on_host_msg}'", self.log_to_slack)
         start_response = self._ops.cs.startVirtualMachine(id=self['id'], hostid=host_id)
         if not self._ops.wait_for_job(start_response['jobid']):
             logging.error(f"Failed to start VM '{self['name']}'")

--- a/list_ha_workers.py
+++ b/list_ha_workers.py
@@ -48,7 +48,7 @@ def main(database_server, database_name, database_port, database_user, database_
 
     ha_workers = cs.list_ha_workers(hostname)
     if not ha_workers:
-        sys.exit(0)
+        sys.exit(1)
 
     table_headers = [
         "Domain",
@@ -71,7 +71,7 @@ def main(database_server, database_name, database_port, database_user, database_
             continue
         if non_running and state == 'Running':
             continue
-        if name_filter and not vm_name.find(name_filter):
+        if name_filter and name_filter not in vm_name:
             continue
 
         count += 1

--- a/tests/test_cosmichost.py
+++ b/tests/test_cosmichost.py
@@ -198,8 +198,11 @@ class TestCosmicHost(TestCase):
         self.assertEqual((self.vm_count, self.vm_count, 0), self.host.empty())
         self.user_vm.stop.assert_not_called()
 
-        for vm in self.all_vms:
+        for vm in [self.user_vm, self.project_vm]:
             self.assertEqual('host_normal', vm.migrate.call_args[0][0]['id'])
+
+        for vm in [self.router_vm, self.project_router_vm, self.secondary_storage_vm, self.console_proxy]:
+            self.assertEqual('host_explicit_group_2', vm.migrate.call_args[0][0]['id'])
 
     def test_empty_dry_run(self):
         self.host._ops.dry_run = True

--- a/tests/test_list_ha_workers.py
+++ b/tests/test_list_ha_workers.py
@@ -23,14 +23,78 @@ import list_ha_workers
 class TestListHAWorkers(TestCase):
     def setUp(self):
         cs_patcher = patch('list_ha_workers.CosmicSQL')
+        tabulate_patcher = patch('list_ha_workers.tabulate')
         self.cs = cs_patcher.start()
+        self.tabulate = tabulate_patcher.start()
         self.addCleanup(cs_patcher.stop)
+        self.addCleanup(tabulate_patcher.stop)
         self.cs_instance = self.cs.return_value
         self.runner = CliRunner()
+        self.workers = ((
+                            'domain_1',
+                            'vm_name_1',
+                            'vm_type_1',
+                            'Running',
+                            'created_1',
+                            'taken_1',
+                            'step_1',
+                            'host_1',
+                            'mgt_server_1',
+                            'ha_state_1'
+                        ), (
+                            'domain_2',
+                            '',
+                            'vm_type_2',
+                            'Running',
+                            'created_2',
+                            'taken_2',
+                            'step_2',
+                            'host_2',
+                            'mgt_server_2',
+                            'ha_state_2'
+                        ), (
+                            'domain_3',
+                            'vm_name_3',
+                            'vm_type_3',
+                            'Stopped',
+                            'created_3',
+                            'taken_3',
+                            'step_3',
+                            'host_3',
+                            'mgt_server_3',
+                            'ha_state_3'
+                        ),)
+
+        self.cs_instance.list_ha_workers.return_value = self.workers
 
     def test_main(self):
-        result = self.runner.invoke(list_ha_workers.main, ['-s', 'server_address', '-p', 'password'])
+        self.assertEqual(0,
+                         self.runner.invoke(list_ha_workers.main, ['-s', 'server_address', '-p', 'password']).exit_code)
         self.cs.assert_called_with(server='server_address', database='cloud', port=3306, user='cloud',
                                    password='password', dry_run=False)
         self.cs_instance.list_ha_workers.assert_called_with('')
-        self.assertEqual(0, result.exit_code)
+        table_data = self.tabulate.call_args[0][0]
+        flat_data = [worker for workers in table_data for worker in workers]
+        self.assertIn('vm_name_1', flat_data)
+        self.assertNotIn('vm_type_2', flat_data)
+        self.assertIn('vm_name_3', flat_data)
+
+    def test_non_running(self):
+        self.assertEqual(0,
+                         self.runner.invoke(list_ha_workers.main, ['-s', 'server_address', '--non-running']).exit_code)
+        table_data = self.tabulate.call_args[0][0]
+        flat_data = [worker for workers in table_data for worker in workers]
+        self.assertNotIn('vm_name_1', flat_data)
+        self.assertIn('vm_name_3', flat_data)
+
+    def test_name_filter(self):
+        self.assertEqual(0, self.runner.invoke(list_ha_workers.main,
+                                               ['-s', 'server_address', '--name-filter', 'name_1']).exit_code)
+        table_data = self.tabulate.call_args[0][0]
+        flat_data = [worker for workers in table_data for worker in workers]
+        self.assertIn('vm_name_1', flat_data)
+        self.assertNotIn('vm_name_3', flat_data)
+
+    def test_failures(self):
+        self.cs_instance.list_ha_workers.return_value = []
+        self.assertEqual(1, self.runner.invoke(list_ha_workers.main, ['-s', 'db_alias']).exit_code)


### PR DESCRIPTION
Some fixes in various parts of CosmicOps:

* Only perform host dedication check for user VMs. Solves issue with routers not migrating if there are only dedicated hosts in the pod).
* When starting a VM, only show the hostname the VM will be started on if it was passed. Before this change this could be confusing as it displayed the last host the VM was running on.
* Add missing unit tests for `list_ha_workers.py`.
* Fix `--name-filter` option for `list_ha_workers.py` I discovered when adding the missing unit tests :smile: