### PR TITLE
PTY support

### DIFF
--- a/cosmicops/host.py
+++ b/cosmicops/host.py
@@ -257,7 +257,7 @@ class CosmicHost(CosmicObject):
         if mode:
             self._connection.sudo(f'chmod {mode:o} {destination}')
 
-    def execute(self, command, sudo=False, hide_stdout=True):
+    def execute(self, command, sudo=False, hide_stdout=True, pty=False):
         if self.dry_run:
             logging.info(f"Would execute '{command}' on '{self['name']}")
             return
@@ -267,7 +267,7 @@ class CosmicHost(CosmicObject):
         else:
             runner = self._connection.run
 
-        return runner(command, hide=hide_stdout)
+        return runner(command, hide=hide_stdout, pty=pty)
 
     def reboot(self, action=RebootAction.REBOOT):
         reboot_or_halt = 'halt' if action == RebootAction.HALT else 'reboot'
@@ -295,10 +295,10 @@ class CosmicHost(CosmicObject):
                 self.execute('echo b > /proc/sysrq-trigger', sudo=True)
             elif action == RebootAction.UPGRADE_FIRMWARE:
                 logging.info(f"Rebooting '{self['name']}' after firmware upgrade", self.log_to_slack)
-                self.execute("tmux new -d 'yes | sudo /usr/sbin/smartupdate upgrade && sudo reboot'")
+                self.execute("tmux new -d 'yes | sudo /usr/sbin/smartupdate upgrade && sudo reboot'", pty=True)
             elif action == RebootAction.PXE_REBOOT:
                 logging.info(f"PXE Rebooting '{self['name']}' in 10s", self.log_to_slack)
-                self.execute("tmux new -d 'sleep 10 && sudo /usr/sbin/hp-reboot pxe'")
+                self.execute("tmux new -d 'sleep 10 && sudo /usr/sbin/hp-reboot pxe'", pty=True)
             elif action == RebootAction.SKIP:
                 logging.info(f"Skipping reboot for '{self['name']}'", self.log_to_slack)
         except Exception as e:

--- a/rolling_reboot.py
+++ b/rolling_reboot.py
@@ -102,7 +102,7 @@ def main(profile, ignore_hosts, only_hosts, skip_os_version, reboot_action, pre_
             host.copy_file(str(path), f'/tmp/{path.name}', mode=0o755)
 
         if pre_empty_script:
-            host.execute(f'/tmp/{Path(pre_empty_script).name}', sudo=True, hide_stdout=False)
+            host.execute(f'/tmp/{Path(pre_empty_script).name}', sudo=True, hide_stdout=False, pty=True)
 
         if host['resourcestate'] != 'Disabled':
             if not host.disable():
@@ -135,7 +135,7 @@ def main(profile, ignore_hosts, only_hosts, skip_os_version, reboot_action, pre_
         logging.info(f"Host {host['name']} is empty", log_to_slack)
 
         if post_empty_script:
-            host.execute(f'/tmp/{Path(post_empty_script).name}', sudo=True, hide_stdout=False)
+            host.execute(f'/tmp/{Path(post_empty_script).name}', sudo=True, hide_stdout=False, pty=True)
 
         if not host.reboot(reboot_action):
             sys.exit(1)
@@ -145,7 +145,7 @@ def main(profile, ignore_hosts, only_hosts, skip_os_version, reboot_action, pre_
             host.wait_until_online()
 
         if post_reboot_script:
-            host.execute(f'/tmp/{Path(post_reboot_script).name}', sudo=True, hide_stdout=False)
+            host.execute(f'/tmp/{Path(post_reboot_script).name}', sudo=True, hide_stdout=False, pty=True)
 
         if not host.enable():
             sys.exit(1)

--- a/tests/test_cosmichost.py
+++ b/tests/test_cosmichost.py
@@ -442,10 +442,10 @@ class TestCosmicHost(TestCase):
 
     def test_execute(self):
         self.host.execute('cmd')
-        self.connection_instance.run.assert_called_with('cmd', hide=True)
+        self.connection_instance.run.assert_called_with('cmd', hide=True, pty=False)
 
         self.host.execute('cmd', True)
-        self.connection_instance.sudo.assert_called_with('cmd', hide=True)
+        self.connection_instance.sudo.assert_called_with('cmd', hide=True, pty=False)
 
     def test_execute_dry_run(self):
         self.host.dry_run = True
@@ -465,9 +465,9 @@ class TestCosmicHost(TestCase):
         self.assertTrue(self.host.reboot(RebootAction.FORCE_RESET))
         self.host.execute.assert_has_calls([call('sync', sudo=True), call('echo b > /proc/sysrq-trigger', sudo=True)])
         self.assertTrue(self.host.reboot(RebootAction.UPGRADE_FIRMWARE))
-        self.host.execute.assert_called_with("tmux new -d 'yes | sudo /usr/sbin/smartupdate upgrade && sudo reboot'")
+        self.host.execute.assert_called_with("tmux new -d 'yes | sudo /usr/sbin/smartupdate upgrade && sudo reboot'", pty=True)
         self.assertTrue(self.host.reboot(RebootAction.PXE_REBOOT))
-        self.host.execute.assert_called_with("tmux new -d 'sleep 10 && sudo /usr/sbin/hp-reboot pxe'")
+        self.host.execute.assert_called_with("tmux new -d 'sleep 10 && sudo /usr/sbin/hp-reboot pxe'", pty=True)
         self.assertTrue(self.host.reboot(RebootAction.SKIP))
         self.host.execute.assert_called_with('virsh list | grep running | wc -l')
 

--- a/tests/test_rolling_reboot.py
+++ b/tests/test_rolling_reboot.py
@@ -131,9 +131,9 @@ class TestRollingReboot(TestCase):
             host.copy_file.assert_has_calls([call('pre_empty_script.sh', '/tmp/pre_empty_script.sh', mode=0o755),
                                              call('post_empty_script.sh', '/tmp/post_empty_script.sh', mode=0o755),
                                              call('post_reboot_script.sh', '/tmp/post_reboot_script.sh', mode=0o755)])
-            host.execute.assert_has_calls([call('/tmp/pre_empty_script.sh', sudo=True, hide_stdout=False),
-                                           call('/tmp/post_empty_script.sh', sudo=True, hide_stdout=False),
-                                           call('/tmp/post_reboot_script.sh', sudo=True, hide_stdout=False)])
+            host.execute.assert_has_calls([call('/tmp/pre_empty_script.sh', sudo=True, hide_stdout=False, pty=True),
+                                           call('/tmp/post_empty_script.sh', sudo=True, hide_stdout=False, pty=True),
+                                           call('/tmp/post_reboot_script.sh', sudo=True, hide_stdout=False, pty=True)])
 
     def test_failures(self):
         # Cluster lookup failure


### PR DESCRIPTION
Add support for pty creation to `CosmicHost.execute`, enable it for rolling reboot scripts and anything using tmux.