### PR TITLE
Check if volume size is different instead of smaller

### DIFF
--- a/live_migrate_virtual_machine.py
+++ b/live_migrate_virtual_machine.py
@@ -94,7 +94,7 @@ def live_migrate(co, cs, cluster, vm, destination_dc, add_affinity_group, is_pro
         for path, disk_info in disk_info.items():
             _, path, _, _, size = cs.get_volume_size(path)
 
-            if int(size) < int(disk_info['size']):
+            if int(size) != int(disk_info['size']):
                 logging.warning(
                     f"Size for '{disk_info['path']}' in DB ({size}) is less than libvirt reports ({disk_info['size']}), updating DB")
                 cs.update_volume_size(vm['instancename'], path, disk_info['size'])

--- a/live_migrate_virtual_machine_volumes.py
+++ b/live_migrate_virtual_machine_volumes.py
@@ -91,7 +91,7 @@ def live_migrate_volumes(storage_pool, co, cs, dry_run, is_project_vm, log_to_sl
         for path, disk_info in disk_info.items():
             _, path, _, _, size = cs.get_volume_size(path)
 
-            if int(size) < int(disk_info['size']):
+            if int(size) != int(disk_info['size']):
                 logging.warning(
                     f"Size for '{disk_info['path']}' in DB ({size}) is less than libvirt reports ({disk_info['size']}), updating DB")
                 cs.update_volume_size(vm['instancename'], path, disk_info['size'])

--- a/tests/test_cosmichost.py
+++ b/tests/test_cosmichost.py
@@ -616,7 +616,8 @@ class TestCosmicHost(TestCase):
     def test_get_disks(self):
         vm = CosmicVM(Mock(), {
             'id': 'vm1',
-            'name': 'vm'
+            'name': 'vm',
+            'instancename': 'vm'
         })
 
         xml_desc = """


### PR DESCRIPTION
During migration libvirt wants to have the same disk size at the source and destination. This PR will update the disk size if the source volume is different than reported in the DB.