### PR TITLE
New options and fixes

### DIFF
--- a/migrate_offline_volumes.py
+++ b/migrate_offline_volumes.py
@@ -77,7 +77,7 @@ def main(profile, dry_run, ignore_volumes, skip_disk_offerings, only_project, so
         if volume['id'] in ignore_volumes:
             continue
 
-        if volume.get('diskofferingname') in skip_disk_offerings:
+        if skip_disk_offerings and volume.get('diskofferingname') in skip_disk_offerings:
             logging.warning(f"Volume '{volume['name']}' has offering '{volume['diskofferingname']}', skipping...")
             continue
 

--- a/rolling_destroy_svm.py
+++ b/rolling_destroy_svm.py
@@ -43,7 +43,7 @@ def main(profile, dry_run, skip_version, skip_zone):
     svms = co.get_all_systemvms()
     zones = defaultdict(list)
     for svm in svms:
-        if skip_zone and svm['zonename'] == skip_zone:
+        if skip_zone and co.get_host(name=svm['name']).get('zonename') == skip_zone:
             continue
         if skip_version and co.get_host(name=svm['name']).get('version') == skip_version:
             continue

--- a/tests/test_migrate_offline_volumes.py
+++ b/tests/test_migrate_offline_volumes.py
@@ -59,7 +59,8 @@ class TestMigrateOfflineVolumes(TestCase):
             'id': 'v1',
             'name': 'volume1',
             'state': 'Ready',
-            'storage': 'source_storage_pool'
+            'storage': 'source_storage_pool',
+            'diskofferingname': 'disk_test_offering'
         })
 
         self.co_instance.get_cluster.side_effect = [self.source_cluster, self.destination_cluster]

--- a/tests/test_rolling_destroy_svm.py
+++ b/tests/test_rolling_destroy_svm.py
@@ -38,37 +38,46 @@ class TestRollingDestroySVM(TestCase):
         self.svm1 = CosmicSystemVM(Mock(), {
             'id': 's1',
             'name': 's-1-VM',
-            'zonename': 'zone1'
+            'zonename': 'zone1',
+            'zoneid': 'ECC106A3-49EF-41E6-8A49-4C7ADF329A05'
         })
         self.svm1_host = CosmicHost(Mock(), {
             'id': 'sh1',
             'name': 's-1-VM',
             'version': '1.0.0',
             'state': 'Up',
+            'zonename': 'zone1',
+            'zoneid': 'ECC106A3-49EF-41E6-8A49-4C7ADF329A05',
             'resourcestate': 'Enabled'
         })
         self.svm2 = CosmicSystemVM(Mock(), {
             'id': 's2',
             'name': 'v-2-VM',
-            'zonename': 'zone1'
+            'zonename': 'zone2',
+            'zoneid': 'BD687FC1-F138-4B3D-929D-4695F9B6EC98'
         })
         self.svm2_host = CosmicHost(Mock(), {
             'id': 'sh2',
             'name': 'v-2-VM',
             'version': '2.0.0',
             'state': 'Up',
+            'zonename': 'zone2',
+            'zoneid': 'BD687FC1-F138-4B3D-929D-4695F9B6EC98',
             'resourcestate': 'Enabled'
         })
         self.svm3 = CosmicSystemVM(Mock(), {
             'id': 's3',
             'name': 'r-3-VM',
-            'zonename': 'zone1'
+            'zonename': 'zone1',
+            'zoneid': 'ECC106A3-49EF-41E6-8A49-4C7ADF329A05'
         })
         self.svm3_host = CosmicHost(Mock(), {
             'id': 'sh3',
             'name': 'r-3-VM',
             'version': '3.0.0',
             'state': 'Up',
+            'zonename': 'zone1',
+            'zoneid': 'ECC106A3-49EF-41E6-8A49-4C7ADF329A05',
             'resourcestate': 'Enabled'
         })
 
@@ -101,6 +110,18 @@ class TestRollingDestroySVM(TestCase):
     def test_skip_version(self):
         self.assertEqual(0, self.runner.invoke(rolling_destroy_svm.main,
                                                ['--exec', '-p', 'profile', '--skip-version', '2.0.0']).exit_code)
+
+        self.co.assert_called_with(profile='profile', dry_run=False)
+
+        self.co_instance.get_all_systemvms.assert_called()
+        for vm in [self.svm1, self.svm3]:
+            vm.destroy.assert_called()
+
+        self.svm2.destroy.assert_not_called()
+
+    def test_skip_zone(self):
+        self.assertEqual(0, self.runner.invoke(rolling_destroy_svm.main,
+                                               ['--exec', '-p', 'profile', '--skip-zone', 'zone1']).exit_code)
 
         self.co.assert_called_with(profile='profile', dry_run=False)
 


### PR DESCRIPTION
Added new switch in `migrate_offline_volumes.py` to skip disks with a given offering.
Added new switch in `rolling_destroy_vm.py` to skip a given zone, also make the loop more efficient.